### PR TITLE
Adding k-points to `HKLData`

### DIFF
--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -194,10 +194,7 @@ function readWAVECAR(io::IO)
     # containing tuples (containing band energy and occupancy)
     bands = [Vector{NTuple{2,Float64}}(undef, nband) for kp in 1:nkpt]
     # Plane wave coefficients
-    waves = [
-        zeros(HKLData{3,Complex{Float32}}, rlatt, hklbounds...) 
-        for s in 1:nspin, kp in 1:nkpt, b in 1:nband
-    ]
+    waves = Array{HKLData{3,Complex{Float32}},3}(undef, nspin, nkpt, nband)
     # Energy and occupancy data
     energies = zeros(Float64, nspin, nkpt, nband)
     occupancies = zeros(Float64, nspin, nkpt, nband)
@@ -224,6 +221,12 @@ function readWAVECAR(io::IO)
                 "Reciprocal space coordinates: ", @sprintf("[%f %f %f]", klist[kp]...)
             )
             for b in 1:nband
+                # Generate an empty HKLData to be filled later
+                waves[s, kp, b] = HKLData(
+                    rlatt,
+                    zeros(Complex{Float32}, length.(hklbounds)...),
+                    klist[kp]
+                )
                 # Seek to the next entry
                 count +=1; seek(io, count*nrecl)
                 # Reset the HKL indices

--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -190,9 +190,6 @@ function readWAVECAR(io::IO)
     hklbounds = SVector{3,UnitRange{Int}}(-g:g for g in maxHKLindex(rlatt, ecut))
     # List of k-points
     klist = Vector{SVector{3,Float64}}(undef, nkpt)
-    # Store band info in a vector (of size nkpt) containing vectors (of size nband)
-    # containing tuples (containing band energy and occupancy)
-    bands = [Vector{NTuple{2,Float64}}(undef, nband) for kp in 1:nkpt]
     # Plane wave coefficients
     waves = Array{HKLData{3,Complex{Float32}},3}(undef, nspin, nkpt, nband)
     # Energy and occupancy data


### PR DESCRIPTION
This should allow for a lone `HKLData` struct to be more easily dealt with, as the associated k-point will be included. No need to go back and reference a `KPointGrid` or `KPointList` repeatedly.

I've also updated the logic of `read_abinit_wavefunction()` and `readWAVECAR()` to include the k-points explicitly. I haven't checked how FFTs are handled, but the default constructor for `HKLData` will insert a zero k-point vector if it's not explicitly specified.