### PR TITLE
Helping abinit file reading/writing functions conform with standards

### DIFF
--- a/src/software/abinit.jl
+++ b/src/software/abinit.jl
@@ -862,8 +862,7 @@ function read_abinit_anaddb_out(io::IO)
 end
 
 """
-    read_abinit_anaddb_out(io::IO)
-    read_abinit_anaddb_out(filename::AbstractString)
+    read_abinit_anaddb_out(file)
         -> Tuple{Int64, FatBands{3}, Array{SVector{6,Float64}}, Vector{Float64}}
 
 Reads an output file from anaddb and returns the fineness of the kpoint path,
@@ -885,7 +884,7 @@ to be the first k-point entered in the anaddb analysis.
 
 Energies: Energies are given in a Vector{Float64} with a length matching the number of modes.
 """
-read_abinit_anaddb_out(filename::AbstractString) = open(read_abinit_anaddb_out, filename)
+read_abinit_anaddb_out(filename) = open(read_abinit_anaddb_out, filename)
 
 function read_abinit_anaddb_in(io::IO)
     readuntil(io, "nph1l")  # number of phonons in list 1
@@ -906,8 +905,7 @@ function read_abinit_anaddb_in(io::IO)
 end
 
 """
-    read_abinit_anaddb_in(io::IO) -> Vector{String}    
-    read_abinit_anaddb_in(filename::AbstractString) -> Vector{String}
+    read_abinit_anaddb_in(file) -> Vector{String}
 
 Reads an input file for anaddb to determine the string of the path through reciprocal space
 (`Vector{String}``) to plot the phonon dispersion curves. Also returns the fineness of the k-point
@@ -929,7 +927,7 @@ qph1l       0.00   0.00   0.00   1   !GAMMA
 
 Here, the "GAMMA" and "X" are returned in the Vector{String}.
 """
-read_abinit_anaddb_in(filename::AbstractString) = open(read_abinit_anaddb_in, filename)
+read_abinit_anaddb_in(filename) = open(read_abinit_anaddb_in, filename)
 
 # TODO: refactor this function into multiple methods
 """
@@ -958,6 +956,7 @@ function write_abinit_modes(
     end
 end
 
+# TODO: rewrite this so that it doesn't allocate all of the lines
 """
     read_abinit_anaddb_PHDOS(file) -> Tuple{DensityOfStates, Vector{ProjectedDensityOfStates}}
 

--- a/src/software/abinit.jl
+++ b/src/software/abinit.jl
@@ -926,22 +926,28 @@ function read_abinit_anaddb_in(filename::AbstractString)
     end
 end
 
-    
+# TODO: refactor this function into multiple methods
 """
-    write_abinit_modes(modes::Array{SVector{6,Float64}}, energies::Vector{Float64})
+    write_abinit_modes(
+        modes::AbstractArray{<:StaticVector{6,<:Real}},
+        energies::AbstractVector{<:Real}
+    )
 
 Writes the real and imaginary vectors into a .dat file for each mode. Each line in the .dat file
 corresponds to the real x, y, z then imaginary x, y, z vectors of the corresponding atom. The
 The vectors are Cartesian coordinates.
 """
-function write_abinit_modes(modes::Array{SVector{6,Float64}}, energies::Vector{Float64})
-    for i in 1:length(energies)
+function write_abinit_modes(
+    modes::AbstractArray{<:StaticVector{6,<:Real}},
+    energies::AbstractVector{<:Real}
+)
+    for i in axes(energies, 1)
         filename = string("mode_",i,"_energy_",energies[i],".dat")
-        open(filename,"w") do io
-            for n in 1:size(modes)[2]
+        open(filename, "w") do io
+            for n in axes(modes, 2)
                 # prints real vector then imag vector
                 # cartesian coordinates
-                println(io,strip(string(modes[i,n]),['[',']']))
+                println(io, strip(string(modes[i,n]), ['[',']']))
             end
         end
     end

--- a/src/software/abinit.jl
+++ b/src/software/abinit.jl
@@ -959,17 +959,16 @@ function write_abinit_modes(
 end
 
 """
-    read_abinit_anaddb_PHDOS(filename::AbstractString) 
-        -> Tuple{DensityOfStates, Vector{ProjectedDensityOfStates}}
+    read_abinit_anaddb_PHDOS(file) -> Tuple{DensityOfStates, Vector{ProjectedDensityOfStates}}
 
 Reads the PHDOS file from ABINIT's anaddb script and returns the total phonon density of states and
 atomic contributions to the phonon density of states as a tuple. The PHDOS file is an output from
 the anaddb program in ABINIT that contains information about the phonon density of states, with
 frequencies in units of Hartree.
 """
-function read_abinit_anaddb_PHDOS(filename::AbstractString) 
+function read_abinit_anaddb_PHDOS(file) 
     # Skip header (lines 1-8)
-    data = readlines(filename)[9:end]
+    data = readlines(file)[9:end]
     num_col = length(split(data[1]))
     # Parse data to floating point values
     # Energy | total PHDOS | int PHDOS | AtomType 1 PHDOS | AtomType 1 intPHDOS | ...


### PR DESCRIPTION
I noticed that some of the methods for abinit file writing didn't conform to the (informal, undocumented) standard for file processing methods. Along with having the methods comply with that standard, I refactored them slightly and included some comments for improvement. I realize I should have been more proactive with that feedback earlier on. Since I don't work with anaddb I'd like to get your feedback before merging.

As a future note, I'm going to include some extra documentation for how to contribute file writing methods. The tl;dr is that every file writing function should have a method that accepts a file handle (Julia `IO` subtypes, see the method signatures that contain `(io::IO, args...; kwargs...)`) and then another method that accepts a path. By default we assumed that this was an `AbstractString`, but some packages provide a custom type for paths, so in the future there will be no type restriction.