### PR TITLE
Adding `InlineStrings`  and conversion semantics for `NamedAtom` structs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0-dev"
 [deps]
 ComputedFieldTypes = "459fdd68-db75-56b8-8c15-d717a790f88e"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+InlineStrings = "842dd82b-1e85-43dc-bf29-5d0ee9dffc48"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NormalForms = "109d20d8-9763-411c-9b60-7eb2a068657f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/src/Electrum.jl
+++ b/src/Electrum.jl
@@ -4,8 +4,11 @@ using LinearAlgebra
 using StaticArrays
 using FFTW
 using Printf
+using InlineStrings
 using ComputedFieldTypes
 using NormalForms
+
+import InlineStrings.InlineString15
 
 const ELEMENTS = 
 ( 

--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -1,29 +1,13 @@
 """
     NamedAtom
 
-Stores information about an atom, which includes a name which may be up to 8 codepoints long, and
+Stores information about an atom, which includes a name which may be up to 15 codepoints long, and
 the atomic number.
-
-Internally, the name is stored as a `NTuple{8,Char}` in the `name` field to guarantee that the type
-is pure bits. However, the `name` property returns a `String`.
 """
 struct NamedAtom
-    name::NTuple{8,Char}
+    name::InlineString15
     num::Int
-    function NamedAtom(name::AbstractString, num::Integer)
-        codepoints = ntuple(Val{8}()) do i
-            i <= length(name) ? name[i] : '\0'
-        end
-        return new(codepoints, num)
-    end
-end
-
-function Base.getproperty(atom::NamedAtom, p::Symbol)
-    if p == :name
-        l = findfirst(isequal('\0'), getfield(atom, p))
-        return string(getfield(atom, p)[1:l-1]...)
-    end
-    return getfield(atom, p)
+    NamedAtom(name::AbstractString, num::Integer) = new(name, num)
 end
 
 NamedAtom(num::Integer) = num in 1:118 ? NamedAtom(ELEMENTS[num], num) : NamedAtom("dummy", num)
@@ -35,6 +19,7 @@ Base.isless(a1::NamedAtom, a2::NamedAtom) = isless(a1.num, a2.num) || isless(a1.
 name(a::NamedAtom) = a.name
 atomic_number(a::NamedAtom) = a.num
 isdummy(a::NamedAtom) = (a.num == 0)
+
 """
     Electrum.reset_name(a::NamedAtom)
 

--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -22,7 +22,7 @@ isdummy(a::NamedAtom) = (a.num == 0)
 
 Base.convert(T::Type{<:AbstractString}, a::NamedAtom) = convert(T, name(a))
 Base.convert(T::Type{<:Number}, a::NamedAtom) = convert(T, atomic_number(a))
-Base.convert(::Type{NamedAtom}, x) = NamedAtom(x)
+Base.convert(::Type{NamedAtom}, x::Union{AbstractString,Number}) = NamedAtom(x)
 
 """
     Electrum.reset_name(a::NamedAtom)

--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -20,6 +20,10 @@ name(a::NamedAtom) = a.name
 atomic_number(a::NamedAtom) = a.num
 isdummy(a::NamedAtom) = (a.num == 0)
 
+Base.convert(T::Type{<:AbstractString}, a::NamedAtom) = convert(T, name(a))
+Base.convert(T::Type{<:Number}, a::NamedAtom) = convert(T, atomic_number(a))
+Base.convert(::Type{NamedAtom}, x) = NamedAtom(x)
+
 """
     Electrum.reset_name(a::NamedAtom)
 


### PR DESCRIPTION
Previously, the `NamedAtom` struct was defined like such:
```julia
struct NamedAtom
    name::NTuple{8,Char}
    num::Int
    function NamedAtom(name::AbstractString, num::Integer)
        codepoints = ntuple(Val{8}()) do i
            i <= length(name) ? name[i] : '\0'
        end
        return new(codepoints, num)
    end
end

function Base.getproperty(atom::NamedAtom, p::Symbol)
    if p == :name
        l = findfirst(isequal('\0'), getfield(atom, p))
        return string(getfield(atom, p)[1:l-1]...)
    end
    return getfield(atom, p)
end
```
We used an `NTuple{8,Char}` to store a fixed-length C string so that `NamedAtom` can remain a bits type, and then overloaded `Base.getproperty()` and the constructors to deal with the fact that we want to treat the fixed string data as a Julia string. However, the [InlineStrings.jl](https://github.com/JuliaStrings/InlineStrings.jl) package defines fixed-length strings as their own data type, with all other Julia string operations supported, so this should significantly simplify the code. I've also allowed the name field to hold up to 15 characters, an improvement from the previous 8.

On top of that, I've included conversion semantics for `NamedAtom` structs, allowing them to be converted to strings or numbers easily.