### PR TITLE
Broaden type signatures for file names

### DIFF
--- a/src/filetypes.jl
+++ b/src/filetypes.jl
@@ -27,7 +27,7 @@ function readXYZ(io::IO)
     return AtomList(v)
 end
 
-readXYZ(filename::AbstractString) = open(readXYZ, filename)
+readXYZ(filename) = open(readXYZ, filename)
 
 """
     writeXYZ(io::IO, data::AbstractVector{<:AbstractAtomPosition})
@@ -51,7 +51,7 @@ end
 writeXYZ(io::IO, data::AbstractAtomList) = writeXYZ(io, coord(cartesian(data)))
 writeXYZ(io::IO, data::AbstractCrystal) = writeXYZ(io, atoms(data))
 
-function writeXYZ(filename::AbstractString, data) 
+function writeXYZ(filename, data) 
     open(filename; write=true) do io
         writeXYZ(io, data)
     end
@@ -225,7 +225,7 @@ end
 
 """
     readXSF3D(
-        filename::AbstractString;
+        filename;
         spgrp::Integer = 0,
         origin::AbstractVector{<:Real} = [0, 0, 0]
         ctr::Symbol = :P
@@ -233,8 +233,8 @@ end
 
 Reads an XSF file at path `filename`.
 """
-function readXSF3D(filename::AbstractString; kwargs...)
-    return open(filename) do io
+function readXSF3D(filename; kwargs...)
+    open(filename) do io
         readXSF3D(io; kwargs...)
     end
 end
@@ -337,20 +337,20 @@ function writeXSF(
     writeXSF(io, data(xtaldata), periodic=periodic)
 end
 
-function writeXSF(filename::AbstractString, data...; kwargs...)
+function writeXSF(filename, data...; kwargs...)
     open(filename, write=true) do io
         writeXSF(io, data...; kwargs...)
     end
 end
 
 """
-    readCPcoeff(io::IO, Lmax::Val{L}) -> SphericalComponents{L}
+    readCPcoeff(filename, Lmax::Val{L}=Val{6}()) -> SphericalComponents{L}
 
 Reads in the spherical harmonic projection coefficients from a CPpackage2 calculation.
 
 By default, CPpackage2 gives the coefficients for spherical harmonics up to a maximum l value of 6.
 """
-function readCPcoeff(io::IO, Lmax::Val{L}=Val(6)) where L
+function readCPcoeff(io::IO, Lmax::Val{L}=Val{6}()) where L
     # All the data should be in a Vector{Float64} with this one line
     data = parse.(Float64, [v[2] for v in split.(readlines(io))])
     @debug "$(length(data)) lines in file"
@@ -361,10 +361,10 @@ function readCPcoeff(io::IO, Lmax::Val{L}=Val(6)) where L
     return [SphericalHarmonic{L}(data[(n - 1)*ncoeff .+ (1:ncoeff)]) for n in 1:natom]
 end
 
-readCPcoeff(filename::AbstractString) = open(readCPcoeff, filename)
+readCPcoeff(filename) = open(readCPcoeff, filename)
 
 """
-    readCPgeo(io::IO) -> Vector{AtomPosition{3}}
+    readCPgeo(filename) -> Vector{AtomPosition{3}}
 
 Reads the atomic positions used for a CPpackage2 calculation.
 """
@@ -375,10 +375,10 @@ function readCPgeo(io::IO)
     return AtomPosition{3}.(atomnames, positions)
 end
 
-readCPgeo(filename::AbstractString) = open(readCPgeo, filename)
+readCPgeo(filename) = open(readCPgeo, filename)
 
 """
-    readCPcell(io::IO) -> RealBasis{3}
+    readCPcell(filename) -> RealBasis{3}
 
 Reads the basis vectors of the unit cell used for a CPpackage2 calculation.
 """
@@ -387,4 +387,4 @@ function readCPcell(io::IO)
     return RealBasis{3}(matrix)
 end
 
-readCPcell(filename::AbstractString) = open(readCPcell, filename)
+readCPcell(filename) = open(readCPcell, filename)

--- a/src/filetypes.jl
+++ b/src/filetypes.jl
@@ -225,7 +225,7 @@ end
 
 """
     readXSF3D(
-        filename;
+        file;
         spgrp::Integer = 0,
         origin::AbstractVector{<:Real} = [0, 0, 0]
         ctr::Symbol = :P
@@ -344,7 +344,7 @@ function writeXSF(filename, data...; kwargs...)
 end
 
 """
-    readCPcoeff(filename, Lmax::Val{L}=Val{6}()) -> SphericalComponents{L}
+    readCPcoeff(file, Lmax::Val{L}=Val{6}()) -> SphericalComponents{L}
 
 Reads in the spherical harmonic projection coefficients from a CPpackage2 calculation.
 
@@ -364,7 +364,7 @@ end
 readCPcoeff(filename) = open(readCPcoeff, filename)
 
 """
-    readCPgeo(filename) -> Vector{AtomPosition{3}}
+    readCPgeo(file) -> Vector{AtomPosition{3}}
 
 Reads the atomic positions used for a CPpackage2 calculation.
 """
@@ -378,7 +378,7 @@ end
 readCPgeo(filename) = open(readCPgeo, filename)
 
 """
-    readCPcell(filename) -> RealBasis{3}
+    readCPcell(file) -> RealBasis{3}
 
 Reads the basis vectors of the unit cell used for a CPpackage2 calculation.
 """

--- a/src/software/abinit.jl
+++ b/src/software/abinit.jl
@@ -667,7 +667,7 @@ function read_abinit_density(io::IO)
 end
 
 """
-    read_abinit_density(filename)
+    read_abinit_density(file)
         -> CrystalWithDatasets{3,String,RealSpaceDataGrid{3,Float64}}
 
 Reads a FORTRAN binary formatted abinit density file. By default, abinit density files will have
@@ -707,7 +707,7 @@ function read_abinit_potential(io::IO)
 end
 
 """
-    read_abinit_potential(filename)
+    read_abinit_potential(file)
         -> CrystalWithDatasets{3,String,RealSpaceDataGrid{3,T}} where T<:Union{Float64,ComplexF64}
 
 Reads a FORTRAN binary formatted abinit potential file.
@@ -801,7 +801,7 @@ function read_abinit_wavefunction(io::IO)
 end
 
 """
-    read_abinit_wavefunction(filename)
+    read_abinit_wavefunction(file)
         -> CrystalWithDatasets{3,String,ReciprocalWavefunction{3,Float64}}
 
 Reads a FORTRAN binary formatted abinit potential file. 

--- a/src/software/abinit.jl
+++ b/src/software/abinit.jl
@@ -571,7 +571,7 @@ function read_abinit_header_80(io::IO)
 end
 
 """
-    Electrum.read_abinit_header(io::IO)
+    Electrum.read_abinit_header(io::IO) -> Electrum.ABINITHeader
 
 Reads the header of an ABINIT output file, automatically determining the format of the header from
 the first few digits.
@@ -667,7 +667,7 @@ function read_abinit_density(io::IO)
 end
 
 """
-    read_abinit_density(filename::AbstractString)
+    read_abinit_density(filename)
         -> CrystalWithDatasets{3,String,RealSpaceDataGrid{3,Float64}}
 
 Reads a FORTRAN binary formatted abinit density file. By default, abinit density files will have
@@ -681,7 +681,7 @@ with explicit treatment of spin will return spin densities.
 
 Depending on the value of `cplex`, the datagrid(s) returned may be real or complex-valued.
 """
-read_abinit_density(filename::AbstractString) = open(read_abinit_density, filename)
+read_abinit_density(filename) = open(read_abinit_density, filename)
 
 function read_abinit_potential(io::IO)
     # Get the header from the file
@@ -707,7 +707,7 @@ function read_abinit_potential(io::IO)
 end
 
 """
-    read_abinit_potential(filename::AbstractString)
+    read_abinit_potential(filename)
         -> CrystalWithDatasets{3,String,RealSpaceDataGrid{3,T}} where T<:Union{Float64,ComplexF64}
 
 Reads a FORTRAN binary formatted abinit potential file.
@@ -724,7 +724,7 @@ explicit treatment of spin will return spin-dependent potentials.
 
 Depending on the value of `cplex`, the datagrid(s) returned may be real or complex-valued.
 """
-read_abinit_potential(filename::AbstractString) = open(read_abinit_potential, filename)
+read_abinit_potential(filename) = open(read_abinit_potential, filename)
 
 function read_abinit_wavefunction(io::IO)
     # Get the header from the file
@@ -801,7 +801,7 @@ function read_abinit_wavefunction(io::IO)
 end
 
 """
-    read_abinit_wavefunction(filename::AbstractString)
+    read_abinit_wavefunction(filename)
         -> CrystalWithDatasets{3,String,ReciprocalWavefunction{3,Float64}}
 
 Reads a FORTRAN binary formatted abinit potential file. 
@@ -818,7 +818,7 @@ explicit treatment of spin will return spin-dependent potentials.
 
 Depending on the value of `cplex`, the datagrid(s) returned may be real or complex-valued.
 """
-read_abinit_wavefunction(filename::AbstractString) = open(read_abinit_wavefunction, filename)
+read_abinit_wavefunction(filename) = open(read_abinit_wavefunction, filename)
 
 const read_abinit_DEN = read_abinit_density
 const read_abinit_POT = read_abinit_potential

--- a/src/software/lammps.jl
+++ b/src/software/lammps.jl
@@ -76,11 +76,11 @@ function write_lammps_data(io::IO, xtal::AbstractCrystal, transform; kwargs...)
 end
 
 """
-    write_lammps_data(filename::AbstractString, data, [transform]; dummy::Bool = false)
+    write_lammps_data(filename, data, [transform]; dummy::Bool = false)
 
 Writes a LAMMPS data file to the path given by `filename`.
 """
-function write_lammps_data(filename::AbstractString, args...; kwargs...)
+function write_lammps_data(filename, args...; kwargs...)
     open(filename, write=true) do io
         write_lammps_data(io, args...; kwargs...)
     end

--- a/src/software/lammps.jl
+++ b/src/software/lammps.jl
@@ -76,7 +76,7 @@ function write_lammps_data(io::IO, xtal::AbstractCrystal, transform; kwargs...)
 end
 
 """
-    write_lammps_data(filename, data, [transform]; dummy::Bool = false)
+    write_lammps_data(file, data, [transform]; dummy::Bool = false)
 
 Writes a LAMMPS data file to the path given by `filename`.
 """

--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -1,6 +1,6 @@
 """
-    readPOSCAR(filename) -> PeriodicAtomList{3}
-    readCONTCAR(filename) -> PeriodicAtomList{3}
+    readPOSCAR(file) -> PeriodicAtomList{3}
+    readCONTCAR(file) -> PeriodicAtomList{3}
 
 Reads a VASP POSCAR or CONTCAR file.
 
@@ -84,7 +84,7 @@ readPOSCAR() = open(readPOSCAR, "POSCAR")
 readCONTCAR() = open(readPOSCAR, "CONTCAR")
 
 """
-    writePOSCAR4(filename, data; kwargs...)
+    writePOSCAR4(file, data; kwargs...)
 
 Writes crystal data to a VASP 4.6 POSCAR output. The `data` can be a `PeriodicAtomList` or an
 `AbstractCrystal`.
@@ -140,7 +140,7 @@ end
 
 # Kendall got everything done before 6 PM (2022-02-01)
 """
-    readWAVECAR(filename) -> ReciprocalWavefunction{3,Float32}
+    readWAVECAR(file) -> ReciprocalWavefunction{3,Float32}
 
 Reads a WAVECAR file output from a VASP 4.6 calcuation.
 
@@ -261,7 +261,7 @@ end
 readWAVECAR() = readWAVECAR("WAVECAR")
 
 """
-    readDOSCAR(filename) -> Tuple{DensityOfStates, Vector{ProjectedDensityOfStates}}
+    readDOSCAR(file) -> Tuple{DensityOfStates, Vector{ProjectedDensityOfStates}}
 
 Reads a DOSCAR file from VASP and returns its data as a tuple containing the total and projected
 density of states (if present).
@@ -325,7 +325,7 @@ end
 readDOSCAR() = open(readDOSCAR, "DOSCAR")
 
 """
-    readPROCAR(filename) -> FatBands{3}
+    readPROCAR(file) -> FatBands{3}
 
 Reads an lm-decomposed PROCAR file from VASP and returns its data as a `FatBands{3}`.
 """
@@ -400,7 +400,7 @@ end
 readPROCAR() = open(readPROCAR, "PROCAR")
 
 """
-    get_fermi(filename) -> NamedTuple{(:fermi, :alphabeta), NTuple{2,Float64}}
+    get_fermi(file) -> NamedTuple{(:fermi, :alphabeta), NTuple{2,Float64}}
 
 Reads an OUTCAR file and returns the Fermi Energy and alpha+beta value.
 """
@@ -417,7 +417,7 @@ get_fermi(filename) = open(get_fermi, filename)
 get_fermi() = open(get_fermi, "OUTCAR")
 
 """
-    readKPOINTS(filename) -> KPointGrid{3}
+    readKPOINTS(file) -> KPointGrid{3}
 
 Reads a KPOINTS file to get the k-point mesh. Currently, it only supports grid-generated meshes.
 """

--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -1,6 +1,6 @@
 """
-    readPOSCAR(io::IO) -> PeriodicAtomList{3}
-    readCONTCAR(io::IO) -> PeriodicAtomList{3}
+    readPOSCAR(filename) -> PeriodicAtomList{3}
+    readCONTCAR(filename) -> PeriodicAtomList{3}
 
 Reads a VASP POSCAR or CONTCAR file.
 
@@ -64,7 +64,7 @@ end
 # This can't be a simple alias, because `readCONTCAR()` needs to find a file name `CONTCAR`
 readCONTCAR(io::IO) = readPOSCAR(io)
 
-function readPOSCAR(filename::AbstractString)
+function readPOSCAR(filename)
     # Append POSCAR if only a directory name is given
     if last(filename) == '/'
         filename = filename * "POSCAR"
@@ -72,7 +72,7 @@ function readPOSCAR(filename::AbstractString)
     open(readPOSCAR, filename)
 end
 
-function readCONTCAR(filename::AbstractString)
+function readCONTCAR(filename)
     # Append POSCAR if only a directory name is given
     if last(filename) == '/'
         filename = filename * "CONTCAR"
@@ -84,17 +84,10 @@ readPOSCAR() = open(readPOSCAR, "POSCAR")
 readCONTCAR() = open(readPOSCAR, "CONTCAR")
 
 """
-    writePOSCAR4(
-        io::IO,
-        list::AtomList;
-        comment = Written by Electrum.jl,
-        names::Bool = false,
-        dummy::Bool = false,
-    )
-    writePOSCAR4(io::IO, xtal::AbstractCrystal; kwargs...)
-    writePOSCAR4(filename::AbstractString, data; kwargs...)
+    writePOSCAR4(filename, data; kwargs...)
 
-Writes crystal data to a VASP 4.6 POSCAR output.
+Writes crystal data to a VASP 4.6 POSCAR output. The `data` can be a `PeriodicAtomList` or an
+`AbstractCrystal`.
 
 By default, atom names are not written (since this seems to break VASP 4.6) but this may be
 overridden by setting `names` to `true` (which prevents VESTA from crashing). Dummy atoms are not
@@ -135,7 +128,7 @@ end
 
 writePOSCAR4(io::IO, xtal::AbstractCrystal; kwargs...) = writePOSCAR4(io, xtal.atoms; kwargs...)
 
-function writePOSCAR4(filename::AbstractString, data; kwargs...) 
+function writePOSCAR4(filename, data; kwargs...) 
     # Append POSCAR if only a directory name is given
     if last(filename) == '/'
         filename = filename * "POSCAR"
@@ -147,7 +140,7 @@ end
 
 # Kendall got everything done before 6 PM (2022-02-01)
 """
-    readWAVECAR(io::IO) -> ReciprocalWavefunction{3,Float32}
+    readWAVECAR(filename) -> ReciprocalWavefunction{3,Float32}
 
 Reads a WAVECAR file output from a VASP 4.6 calcuation.
 
@@ -257,7 +250,7 @@ function readWAVECAR(io::IO)
     return ReciprocalWavefunction(rlatt, KPointList(klist), waves, energies, occupancies)
 end
 
-function readWAVECAR(filename::AbstractString)
+function readWAVECAR(filename)
     # Append WAVECAR if only a directory name is given
     if last(filename) == '/'
         filename = filename * "WAVECAR"
@@ -268,7 +261,7 @@ end
 readWAVECAR() = readWAVECAR("WAVECAR")
 
 """
-    readDOSCAR(io::IO) -> Tuple{DensityOfStates, Vector{ProjectedDensityOfStates}}
+    readDOSCAR(filename) -> Tuple{DensityOfStates, Vector{ProjectedDensityOfStates}}
 
 Reads a DOSCAR file from VASP and returns its data as a tuple containing the total and projected
 density of states (if present).
@@ -321,7 +314,7 @@ function readDOSCAR(io::IO)
     return (tdos, pdos)
 end
 
-function readDOSCAR(filename::AbstractString; kwargs...)
+function readDOSCAR(filename; kwargs...)
     # Append DOSCAR if only a directory name is given
     if last(filename) == '/'
         filename = filename * "DOSCAR"
@@ -332,7 +325,7 @@ end
 readDOSCAR() = open(readDOSCAR, "DOSCAR")
 
 """
-    readPROCAR(io::IO) -> FatBands{3}
+    readPROCAR(filename) -> FatBands{3}
 
 Reads an lm-decomposed PROCAR file from VASP and returns its data as a `FatBands{3}`.
 """
@@ -396,7 +389,7 @@ function readPROCAR(io::IO)
     )
 end
 
-function readPROCAR(filename::AbstractString)
+function readPROCAR(filename)
     # Append PROCAR if only a directory name is given
     if last(filename) == '/'
         filename = filename * "PROCAR"
@@ -407,7 +400,7 @@ end
 readPROCAR() = open(readPROCAR, "PROCAR")
 
 """
-    get_fermi(io::IO) -> NamedTuple{(:fermi, :alphabeta), NTuple{2,Float64}}
+    get_fermi(filename) -> NamedTuple{(:fermi, :alphabeta), NTuple{2,Float64}}
 
 Reads an OUTCAR file and returns the Fermi Energy and alpha+beta value.
 """
@@ -419,12 +412,12 @@ function get_fermi(io::IO)
     return (fermi = fermi, alphabeta = alphabeta)
 end
 
-get_fermi(filename::AbstractString) = open(get_fermi, filename)
+get_fermi(filename) = open(get_fermi, filename)
 
 get_fermi() = open(get_fermi, "OUTCAR")
 
 """
-    readKPOINTS(io::IO) -> KPointGrid{3}
+    readKPOINTS(filename) -> KPointGrid{3}
 
 Reads a KPOINTS file to get the k-point mesh. Currently, it only supports grid-generated meshes.
 """
@@ -441,7 +434,7 @@ function readKPOINTS(io::IO)
     return kptgrid
 end    
 
-function readKPOINTS(filename::AbstractString)
+function readKPOINTS(filename)
     # Append KPOINTS if only a directory name is given
     if last(filename) == '/'
         filename = filename * "KPOINTS"


### PR DESCRIPTION
Some people like using packages such as [FilePathsBase.jl](https://github.com/rofinn/FilePathsBase.jl) which provide a custom path type. However, for many file reading functions, the filename argument was required to be an `AbstractString`, which the `AbstractPath` type from `FilePathsBase` is not. This should solve the issue for everyone.