### PR TITLE
Fixed indexing for `KPointList`

### DIFF
--- a/src/data/reciprocalspace.jl
+++ b/src/data/reciprocalspace.jl
@@ -61,6 +61,7 @@ Base.length(k::KPointList) = length(k.points)
 
 # Get the k-point and its associated weight as a NamedTuple
 Base.getindex(k::KPointList, i::Integer) = (kpt=k.points[i], weight=k.weights[i])
+Base.getindex(k::KPointList, i) = KPointList(k.points[i], k.weights[i])
 
 function Base.setindex!(k::KPointList, v::AbstractVector, i)
     k.points[i] = v

--- a/src/data/reciprocalspace.jl
+++ b/src/data/reciprocalspace.jl
@@ -54,6 +54,8 @@ function KPointList{D}(
     return KPointList(svpoints, weights)
 end
 
+Base.:(==)(k1::KPointList, k2::KPointList) = k1.points == k2.points && k1.weights == k2.weights
+
 Base.axes(k::KPointList) = axes(k.points)
 Base.keys(k::KPointList) = keys(k.points)
 Base.size(k::KPointList) = size(k.points)

--- a/src/data/reciprocalspace.jl
+++ b/src/data/reciprocalspace.jl
@@ -49,7 +49,7 @@ function KPointList{D}(
     points::AbstractVector{<:AbstractVector{<:Real}},
     weights::AbstractVector{<:Real} = ones(length(points))
 ) where D
-    @assert length.(points) == D "k-points have the wrong dimensionality"
+    @assert all(isequal(D), length.(points)) "k-points have the wrong dimensionality"
     svpoints = [SVector{D,Float64}(v) for v in points]
     return KPointList(svpoints, weights)
 end

--- a/src/data/reciprocalspace.jl
+++ b/src/data/reciprocalspace.jl
@@ -54,8 +54,13 @@ function KPointList{D}(
     return KPointList(svpoints, weights)
 end
 
+Base.axes(k::KPointList) = axes(k.points)
+Base.keys(k::KPointList) = keys(k.points)
+Base.size(k::KPointList) = size(k.points)
+Base.length(k::KPointList) = length(k.points)
+
 # Get the k-point and its associated weight as a NamedTuple
-Base.getindex(k::KPointList, i) = (kpt=k.points[i], weight=k.weights[i])
+Base.getindex(k::KPointList, i::Integer) = (kpt=k.points[i], weight=k.weights[i])
 
 function Base.setindex!(k::KPointList, v::AbstractVector, i)
     k.points[i] = v
@@ -70,7 +75,6 @@ Base.lastindex(k::KPointList) = lastindex(k.points)
 Gets the number of k-points in a `KPointList` or a `KPointGrid`.
 """
 nkpt(k::KPointList) = length(k.points)
-Base.length(k::KPointList) = length(k.points)
 
 # Iterate through a KPointList
 Base.iterate(k::KPointList) = (k[1], 2)

--- a/src/data/reciprocalspace.jl
+++ b/src/data/reciprocalspace.jl
@@ -38,7 +38,7 @@ struct KPointList{D} <: AbstractKPointSet{D}
     weights::Vector{Float64}
     function KPointList(
         points::AbstractVector{<:StaticVector{D,<:Real}},
-        weights::AbstractVector{<:Real}
+        weights::AbstractVector{<:Real} = ones(length(points))
     ) where D
         @assert length(points) == length(weights) "Number of k-points and weights do not match."
         return new{D}(points, weights / sum(weights))
@@ -47,19 +47,11 @@ end
 
 function KPointList{D}(
     points::AbstractVector{<:AbstractVector{<:Real}},
-    weights::AbstractVector{<:Real}
+    weights::AbstractVector{<:Real} = ones(length(points))
 ) where D
     @assert length.(points) == D "k-points have the wrong dimensionality"
     svpoints = [SVector{D,Float64}(v) for v in points]
     return KPointList(svpoints, weights)
-end
-
-function KPointList{D}(points::AbstractVector{<:AbstractVector{<:Real}}) where D
-    return KPointList{D}(points, ones(length(points)))
-end
-
-function KPointList(points::AbstractVector{<:StaticVector{D,<:Real}}) where D
-    return KPointList(points, ones(length(points)))
 end
 
 # Get the k-point and its associated weight as a NamedTuple

--- a/src/show.jl
+++ b/src/show.jl
@@ -204,6 +204,17 @@ end
 
 #---Types from data/reciprocalspace.jl-------------------------------------------------------------#
 
+function Base.summary(io::IO, k::KPointList)
+    print(io, length(k), "-element ", typeof(k), ":")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", k::KPointList)
+    summary(io, k)
+    for n in eachindex(k)
+        print(io, "\n ", k.points[n], " (weight ", k.weights[n], ")")
+    end
+end
+
 function Base.show(io::IO, ::MIME"text/plain", g::HKLData)
     dimstring = join(string.(size(g)), "×") * " "
     println(io, dimstring, typeof(g), " with reciprocal space basis vectors:")

--- a/test/kpoints.jl
+++ b/test/kpoints.jl
@@ -1,0 +1,20 @@
+@testset "K-points" begin
+    klist = KPointList(
+        SVector{3,Float64}[
+            [0.0, 0.0, 0.0],
+            [0.5, 0.0, 0.0],
+            [0.0, 0.5, 0.0],
+            [0.0, 0.0, 0.5]
+        ]
+    )
+    @test nkpt(klist) == 4
+    @test length(klist) == 4
+    @test size(klist) == (4,)
+    @test axes(klist) == (Base.OneTo(4),)
+    @test sum(klist.weights) ≈ 1
+    # This will have to change when the weights are stored as integers
+    # Direct comparison causes the weights to change since they are normalized to 1
+    klist2 = KPointList(klist.points[1:3], klist.weights[1:3])
+    @test klist[1:3] == klist2
+    @test sum(klist.weights) ≈ 1
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,4 +22,5 @@ lammps = read_lammps_data("files/lammps.data", atom_types = [14, 77])
     include("datagrids.jl")
     include("supercell.jl")
     include("filetypes.jl")
+    include("kpoints.jl")
 end


### PR DESCRIPTION
Now if a range of k-points is used as the index, the object returned is another `KPointList`. This is a temporary fix as #150 should completely rework a lot of the `KPointList` internals.

But I've also included pretty printing methods for `KPointList` which should be relevant even afterwards.