### PR TITLE
Excluded irrelevant files from codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,6 @@ coverage:
       default:
         target: 30%    # the required coverage value
         threshold: 5%  # the leniency in hitting the target
+ignore:
+  - src/metrics.jl      # No include() statement for this file
+  - src/show.jl


### PR DESCRIPTION
That includes `src/metrics.jl`, which isn't used, and `src/show.jl` which doesn't really need testing.