### PR TITLE
Tools for working with FFT binning

### DIFF
--- a/src/Electrum.jl
+++ b/src/Electrum.jl
@@ -96,8 +96,9 @@ Computes the dot product of a vector with itself.
 """
 _selfdot(v) = dot(v,v)
 
-# Methods used in vector operations that go beyond what's available in LinearAlgebra
+# Methods used in array operations that go beyond what's available in LinearAlgebra
 include("math.jl")
+export FFTBins, FFTLength
 # Abstract types used in type tree
 include("types.jl")
 export AbstractBasis, AbstractCrystal, AbstractDataGrid, AbstractKPointSet, AbstractDensityOfStates

--- a/src/data/fft.jl
+++ b/src/data/fft.jl
@@ -13,16 +13,12 @@ For reciprocal space data, the frequencies are binned with the assumption that t
 are given in angular wavenumbers, and they represent real space coordinates. The Nyquist frequency
 convention is *not* used, so all elements will have positive indices.
 """
-function FFTW.fftfreq(g::AbstractDataGrid{D}, ::ByRealSpace) where D
-    return SVector{D}.(
-        Iterators.product(
-            (fftfreq(size(g)[d], 2π .* size(g)[d] / lengths(basis(g))[d]) for d in 1:D)...
-        )
-    )
+function FFTW.fftfreq(g::AbstractDataGrid, ::ByRealSpace)
+    return map(i -> SVector(2π .* Tuple(i) ./ size(g)), FFTBins(g))
 end
 
-function FFTW.fftfreq(g::AbstractDataGrid{D}, ::ByReciprocalSpace) where D
-    return SVector{D}.(Iterators.product((axes(g) .* lengths(basis(g)) ./ 2π)...))
+function FFTW.fftfreq(g::AbstractDataGrid, ::ByReciprocalSpace)
+    return map(i -> SVector(Tuple(i) .* size(g) ./ 2π), CartesianIndices(g))
 end
 
 FFTW.fftfreq(g::AbstractDataGrid) = fftfreq(g::AbstractDataGrid, data_space(g))

--- a/src/data/grids.jl
+++ b/src/data/grids.jl
@@ -16,12 +16,7 @@ Base.getindex(g::AbstractDataGrid, i...) = getindex(g.data, reinterpret_index(g,
 Base.setindex!(g::AbstractDataGrid, x, i...) = setindex!(g.data, x, reinterpret_index(g, i)...)
 
 # Indexing depends on the data space trait
-function Base.CartesianIndices(g::AbstractDataGrid)
-    if data_space(g) isa ReciprocalSpaceData
-        return CartesianIndices(Tuple((1:n) .- (div(n, 2) + 1) for n in size(g)))
-    end
-    return CartesianIndices(axes(g))
-end
+Base.CartesianIndices(g::AbstractDataGrid) = CartesianIndices(axes(g))
 
 #---Grid similarity checks-------------------------------------------------------------------------#
 """

--- a/test/datagrids.jl
+++ b/test/datagrids.jl
@@ -7,9 +7,18 @@
     @test g[1,1,1] === 1.732
     @test g[1,2,3] === 3.742
 end
+
 @testset "Fourier transforms" begin
     g = xsf["this_is_3Dgrid#1"]
     hkl = fft(g)
     # Check that the Fourier transform and its inverse undo each other
     @test g ≈ ifft(fft(g))
+    # Test FFT indexing mechanics
+    @test collect(FFTLength(4)) == [0, 1, -2, -1]
+    @test collect(FFTLength(5)) == [0, 1, 2, -2, -1]
+    @test sort(FFTLength(4)) == -2:1
+    @test sort(FFTLength(5)) == -2:2
+    @test collect(FFTBins(4)) == [CartesianIndex(x) for x in [0, 1, -2, -1]]
+    @test collect(FFTBins(3,3)) == [CartesianIndex(x,y) for x in [0, 1, -1], y in [0, 1, -1]]
+    @test FFTBins(CartesianIndices(FFTBins(3,3))) == FFTBins(3,3)
 end


### PR DESCRIPTION
I've created the new `FFTBins` and `FFTLength` types that can be used to work with data that's been Fourier transformed and types whose indices are effectively FFT bins.