### PR TITLE
POSCAR/CONTCAR writing improvements

### DIFF
--- a/src/Electrum.jl
+++ b/src/Electrum.jl
@@ -142,7 +142,7 @@ export read_abinit_density, read_abinit_potential, read_abinit_wavefunction, rea
     read_abinit_POT, read_abinit_anaddb_out, read_abinit_WFK, read_abinit_anaddb_in,
     write_abinit_modes, read_abinit_anaddb_PHDOS
 include("software/vasp.jl")
-export readPOSCAR, readCONTCAR, writePOSCAR4, readWAVECAR, readDOSCAR, readPROCAR, get_fermi,
+export readPOSCAR, readCONTCAR, writePOSCAR, readWAVECAR, readDOSCAR, readPROCAR, get_fermi,
     readKPOINTS
 include("software/lammps.jl")
 export read_lammps_data, write_lammps_data

--- a/src/Electrum.jl
+++ b/src/Electrum.jl
@@ -142,8 +142,9 @@ export read_abinit_density, read_abinit_potential, read_abinit_wavefunction, rea
     read_abinit_POT, read_abinit_anaddb_out, read_abinit_WFK, read_abinit_anaddb_in,
     write_abinit_modes, read_abinit_anaddb_PHDOS
 include("software/vasp.jl")
-export readPOSCAR, readCONTCAR, writePOSCAR, writeCONTCAR, readWAVECAR, readDOSCAR, readPROCAR,
+export readPOSCAR, readCONTCAR, writePOSCAR, writeCONTCAR, readWAVECAR, readDOSCAR,readPROCAR,
     get_fermi, readKPOINTS
+@deprecate writePOSCAR4 writePOSCAR
 include("software/lammps.jl")
 export read_lammps_data, write_lammps_data
 # Show methods for pretty printing this module's structs

--- a/src/Electrum.jl
+++ b/src/Electrum.jl
@@ -142,8 +142,8 @@ export read_abinit_density, read_abinit_potential, read_abinit_wavefunction, rea
     read_abinit_POT, read_abinit_anaddb_out, read_abinit_WFK, read_abinit_anaddb_in,
     write_abinit_modes, read_abinit_anaddb_PHDOS
 include("software/vasp.jl")
-export readPOSCAR, readCONTCAR, writePOSCAR, readWAVECAR, readDOSCAR, readPROCAR, get_fermi,
-    readKPOINTS
+export readPOSCAR, readCONTCAR, writePOSCAR, writeCONTCAR, readWAVECAR, readDOSCAR, readPROCAR,
+    get_fermi, readKPOINTS
 include("software/lammps.jl")
 export read_lammps_data, write_lammps_data
 # Show methods for pretty printing this module's structs

--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -299,7 +299,17 @@ Base.filter(f, l::AtomList) = AtomList(filter(f, l.atoms))
 Base.filter(f, l::PeriodicAtomList) = PeriodicAtomList(basis(l), filter(f, l.atoms))
 
 function Base.sort!(l::AbstractAtomList; kwargs...)
-    sort!(l.atoms; by=NamedAtom, kwargs...)
+    function custom_lt(a::T, b::T) where T<:AbstractAtomPosition
+        # 
+        if isequal(NamedAtom(a), NamedAtom(b))
+            for (x, y) in zip(displacement(a), displacement(b))
+                isless(y, x) && return false
+            end
+            return true
+        end
+        return isless(NamedAtom(a), NamedAtom(b))
+    end
+    sort!(l.atoms; lt = custom_lt, kwargs...)
     return l
 end
 

--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -30,7 +30,10 @@ NamedAtom(num::Integer) = num in 1:118 ? NamedAtom(ELEMENTS[num], num) : NamedAt
 NamedAtom(atomname::AbstractString) = NamedAtom(atomname, get(ELEMENT_LOOKUP, atomname, 0))
 
 Base.show(io::IO, atom::NamedAtom) = print(io, "NamedAtom(\"", atom.name, "\", ", atom.num, ")")
-Base.isless(a1::NamedAtom, a2::NamedAtom) = isless(a1.num, a2.num) || isless(a1.name, a2.name)
+
+function Base.isless(a1::NamedAtom, a2::NamedAtom)
+    return isequal(a1.num, a2.num) ? isless(a1.name, a2.name) : isless(a1.num, a2.num)
+end
 
 name(a::NamedAtom) = a.name
 atomic_number(a::NamedAtom) = a.num

--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -1,15 +1,16 @@
 """
     readPOSCAR(file) -> PeriodicAtomList{3}
-    readCONTCAR(file) -> PeriodicAtomList{3}
 
-Reads a VASP POSCAR or CONTCAR file.
+Reads a VASP POSCAR file. A POSCAR contains the basis vectors of the system (potentially given with
+a scaling factor), the positions of all atoms as either Cartesian or reduced coordinates, and
+potentially information needed to perform an ab initio MD run (currently ignored).
 
-A POSCAR contains the basis vectors of the system (potentially given with a scaling factor), the
-positions of all atoms as either Cartesian or reduced coordinates, and potentially information
-needed to perform an ab initio MD run.
+By default, if the provided file path is a directory, `readPOSCAR()` will read from a file named
+`POSCAR` in that directory. If no path is provided, a file named `POSCAR` in the current working
+directory is read.
 
-A CONTCAR file is written at the end of a VASP run and contains the atomic coordinates after the
-calculation completed. This is relevant for geometry optimizations.
+The similar `readCONTCAR` function does much the same as `readPOSCAR`, but defaults to the file name
+`CONTCAR` instead of `POSCAR`.
 """
 function readPOSCAR(io::IO)
     # Skip the comment line
@@ -61,7 +62,16 @@ function readPOSCAR(io::IO)
     return PeriodicAtomList(latt, positions)
 end
 
-# This can't be a simple alias, because `readCONTCAR()` needs to find a file name `CONTCAR`
+"""
+    readCONTCAR(file) -> PeriodicAtomList{3}
+
+Reads a VASP CONTCAR file.  A CONTCAR file is written at the end of a VASP run and contains the
+atomic coordinates after the calculation completed. This is relevant for geometry optimizations or
+molecular dynamics runs.
+
+The function is broadly similar to `readPOSCAR`, but the default file names for directory arguments
+or no argument is `CONTCAR` instead of `POSCAR`. For more help, see `readPOSCAR`.
+"""
 readCONTCAR(io::IO) = readPOSCAR(io)
 
 # Append POSCAR/CONTCAR if only a directory name is given

--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -136,6 +136,8 @@ function writePOSCAR(filename, data; kwargs...)
     open(io -> writePOSCAR(io, data; kwargs...), filename * "/POSCAR"^isdir(filename), write=true)
 end
 
+writePOSCAR(data; kwargs...) = writePOSCAR("POSCAR", data; kwargs...)
+
 # Kendall got everything done before 6 PM (2022-02-01)
 """
     readWAVECAR(file) -> PlanewaveWavefunction{3,Complex{Float32}}

--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -84,11 +84,12 @@ readPOSCAR() = open(readPOSCAR, "POSCAR")
 readCONTCAR() = open(readPOSCAR, "CONTCAR")
 
 """
-    writePOSCAR(file, data; kwargs...)
+    writePOSCAR([file = "POSCAR"], data; names = true, dummy = false, comment)
 
 Writes crystal data to a VASP POSCAR output. The `data` can be a `PeriodicAtomList` or an
 `AbstractCrystal`. If a directory names is given instead of a file name, the data will be written to
-a file named `POSCAR` in the provided directory.
+a file named `POSCAR` in the provided directory. If no filename is provided, it is written to
+`POSCAR` in the current directory.
 
 By default, atom names are written, but this is known to break VASP 4.6. This may be overridden by
 setting `names` to `false`, but this is known to cause its own incompatibility issues: it is known

--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -84,22 +84,25 @@ readPOSCAR() = open(readPOSCAR, "POSCAR")
 readCONTCAR() = open(readPOSCAR, "CONTCAR")
 
 """
-    writePOSCAR4(file, data; kwargs...)
+    writePOSCAR(file, data; kwargs...)
 
-Writes crystal data to a VASP 4.6 POSCAR output. The `data` can be a `PeriodicAtomList` or an
-`AbstractCrystal`.
+Writes crystal data to a VASP POSCAR output. The `data` can be a `PeriodicAtomList` or an
+`AbstractCrystal`. If a directory names is given instead of a file name, the data will be written to
+a file named `POSCAR` in the provided directory.
 
-By default, atom names are not written (since this seems to break VASP 4.6) but this may be
-overridden by setting `names` to `true` (which prevents VESTA from crashing). Dummy atoms are not
-are not written by default, but they may be written by setting `dummy=true`.
+By default, atom names are written, but this is known to break VASP 4.6. This may be overridden by
+setting `names` to `false`, but this is known to cause its own incompatibility issues: it is known
+that VESTA will crash if the line containing the atomic names is missing.
+
+Dummy atoms are not are not written by default, but they may be written by setting `dummy=true`.
 
 The first line, normally used to describe the system, may be altered by passing a printable object
 to `comment`.
 """
-function writePOSCAR4(
+function writePOSCAR(
     io::IO,
     list::PeriodicAtomList;
-    names::Bool = false,
+    names::Bool = true,
     dummy::Bool = false,
     comment = "Written by Electrum.jl"
 )
@@ -126,15 +129,15 @@ function writePOSCAR4(
     end
 end
 
-writePOSCAR4(io::IO, xtal::AbstractCrystal; kwargs...) = writePOSCAR4(io, xtal.atoms; kwargs...)
+writePOSCAR(io::IO, xtal::AbstractCrystal; kwargs...) = writePOSCAR4(io, xtal.atoms; kwargs...)
 
-function writePOSCAR4(filename, data; kwargs...) 
+function writePOSCAR(filename, data; kwargs...) 
     # Append POSCAR if only a directory name is given
     if last(filename) == '/'
         filename = filename * "POSCAR"
     end
     open(filename, write=true) do io
-        writePOSCAR4(io, data; kwargs...)
+        writePOSCAR(io, data; kwargs...)
     end
 end
 

--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -128,9 +128,9 @@ end
 
 writePOSCAR(io::IO, xtal::AbstractCrystal; kwargs...) = writePOSCAR4(io, xtal.atoms; kwargs...)
 
-function writePOSCAR(filename, data; kwargs...)
-    # Append POSCAR if only a directory name is given
-    open(io -> writePOSCAR(io, data; kwargs...), filename * "/POSCAR"^isdir(filename), write=true)
+function writePOSCAR(file, data; kwargs...)
+    f = isdir(file) ? joinpath(file, "CONTCAR") : file
+    open(io -> writePOSCAR(io, data; kwargs...), f, write=true)
 end
 
 writePOSCAR(data; kwargs...) = writePOSCAR("POSCAR", data; kwargs...)
@@ -143,9 +143,9 @@ of `POSCAR`. For more detailed help, see `writePOSCAR`.
 """
 writeCONTCAR(io::IO, data; kwargs...) = writePOSCAR(io, data; kwargs...)
 
-function writeCONTCAR(filename, data; kwargs...)
-    # Append POSCAR if only a directory name is given
-    open(io -> writePOSCAR(io, data; kwargs...), filename * "/CONTCAR"^isdir(filename), write=true)
+function writeCONTCAR(file, data; kwargs...)
+    f = isdir(file) ? joinpath(file, "CONTCAR") : file
+    open(io -> writePOSCAR(io, data; kwargs...), f, write=true)
 end
 
 writeCONTCAR(data; kwargs...) = writePOSCAR("CONTCAR", data; kwargs...)

--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -62,6 +62,9 @@ function readPOSCAR(io::IO)
     return PeriodicAtomList(latt, positions)
 end
 
+readPOSCAR(file) = open(readPOSCAR, isdir(file) ? joinpath(file, "POSCAR") : file)
+readPOSCAR() = open(readPOSCAR, "POSCAR")
+
 """
     readCONTCAR(file) -> PeriodicAtomList{3}
 
@@ -73,12 +76,7 @@ The function is broadly similar to `readPOSCAR`, but the default file names for 
 or no argument is `CONTCAR` instead of `POSCAR`. For more help, see `readPOSCAR`.
 """
 readCONTCAR(io::IO) = readPOSCAR(io)
-
-# Append POSCAR/CONTCAR if only a directory name is given
-readPOSCAR(file) = open(readPOSCAR, isdir(file) ? joinpath(file, "POSCAR") : file)
 readCONTCAR(file) = open(readPOSCAR, isdir(file) ? joinpath(file, "CONTCAR") : file)
-
-readPOSCAR() = open(readPOSCAR, "POSCAR")
 readCONTCAR() = open(readPOSCAR, "CONTCAR")
 
 """

--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -133,12 +133,7 @@ writePOSCAR(io::IO, xtal::AbstractCrystal; kwargs...) = writePOSCAR4(io, xtal.at
 
 function writePOSCAR(filename, data; kwargs...) 
     # Append POSCAR if only a directory name is given
-    if last(filename) == '/'
-        filename = filename * "POSCAR"
-    end
-    open(filename, write=true) do io
-        writePOSCAR(io, data; kwargs...)
-    end
+    open(io -> writePOSCAR(io, data; kwargs...), filename * "/POSCAR"^isdir(filename), write=true)
 end
 
 # Kendall got everything done before 6 PM (2022-02-01)

--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -267,14 +267,10 @@ function readWAVECAR(io::IO; quiet = false)
     return wf
 end
 
-function readWAVECAR(filename; quiet = false)
-    # Append WAVECAR if only a directory name is given
-    if last(filename) == '/'
-        filename = filename * "WAVECAR"
-    end
-    open(io -> readWAVECAR(io; quiet), filename)
+function readWAVECAR(file; quiet = false)
+    open(io -> readWAVECAR(io; quiet), isdir(file) ? joinpath(file, "WAVECAR") : file)
 end
-# Read a WAVECAR in the current directory
+
 readWAVECAR(; quiet = false) = readWAVECAR("WAVECAR"; quiet)
 
 """
@@ -331,14 +327,7 @@ function readDOSCAR(io::IO)
     return (tdos, pdos)
 end
 
-function readDOSCAR(filename; kwargs...)
-    # Append DOSCAR if only a directory name is given
-    if last(filename) == '/'
-        filename = filename * "DOSCAR"
-    end
-    open(readDOSCAR, filename; kwargs...)
-end
-
+readDOSCAR(file) =  open(readDOSCAR, isdir(file) ? joinpath(file, "DOSCAR") : file)
 readDOSCAR() = open(readDOSCAR, "DOSCAR")
 
 """
@@ -406,14 +395,7 @@ function readPROCAR(io::IO)
     )
 end
 
-function readPROCAR(filename)
-    # Append PROCAR if only a directory name is given
-    if last(filename) == '/'
-        filename = filename * "PROCAR"
-    end
-    open(readPROCAR, filename)
-end
-
+readPROCAR(file) = open(readPROCAR, isdir(file) ? joinpath(file, "PROCAR") : file)
 readPROCAR() = open(readPROCAR, "PROCAR")
 
 """
@@ -451,12 +433,5 @@ function readKPOINTS(io::IO)
     return kptgrid
 end    
 
-function readKPOINTS(filename)
-    # Append KPOINTS if only a directory name is given
-    if last(filename) == '/'
-        filename = filename * "KPOINTS"
-    end
-    open(readKPOINTS, filename)
-end
-
+readKPOINTS(file) = open(readKPOINTS, isdir(file) ? joinpath(file, "KPOINTS") : file)
 readKPOINTS() = open(readKPOINTS, "KPOINTS")

--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -154,6 +154,18 @@ end
 
 writeCONTCAR(data; kwargs...) = writePOSCAR("CONTCAR", data; kwargs...)
 
+"""
+    writePOSCAR4([file = "POSCAR"], data; dummy = false, comment)
+
+Writes a POSCAR file readable by VASP 4 (tested on VASP 4.6). This is equivalent to calling
+`writePOSCAR([file = "POSCAR"], data; names = false, dummy = false, comment)` - in other words, the
+names are never written. This can solve segmentation faults that occur with VASP 4.6, but some
+software that depends on these names will misbehave (notably VESTA).
+
+For more details, see `readPOSCAR` (and `readCONTCAR`).
+"""
+writePOSCAR4(args...; kwargs...) = writePOSCAR(args...; kwargs..., names=false)
+
 # Kendall got everything done before 6 PM (2022-02-01)
 """
     readWAVECAR(file) -> PlanewaveWavefunction{3,Complex{Float32}}

--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -132,12 +132,27 @@ end
 
 writePOSCAR(io::IO, xtal::AbstractCrystal; kwargs...) = writePOSCAR4(io, xtal.atoms; kwargs...)
 
-function writePOSCAR(filename, data; kwargs...) 
+function writePOSCAR(filename, data; kwargs...)
     # Append POSCAR if only a directory name is given
     open(io -> writePOSCAR(io, data; kwargs...), filename * "/POSCAR"^isdir(filename), write=true)
 end
 
 writePOSCAR(data; kwargs...) = writePOSCAR("POSCAR", data; kwargs...)
+
+"""
+    writeCONTCAR([file = "CONTCAR"], data; names = true, dummy = false, comment)
+
+Writes crystal data to a VASP POSCAR output, but with the default filename being `CONTCAR` instead
+of `POSCAR`. For more detailed help, see `writePOSCAR`.
+"""
+writeCONTCAR(io::IO, data; kwargs...) = writePOSCAR(io, data; kwargs...)
+
+function writeCONTCAR(filename, data; kwargs...)
+    # Append POSCAR if only a directory name is given
+    open(io -> writePOSCAR(io, data; kwargs...), filename * "/CONTCAR"^isdir(filename), write=true)
+end
+
+writeCONTCAR(data; kwargs...) = writePOSCAR("CONTCAR", data; kwargs...)
 
 # Kendall got everything done before 6 PM (2022-02-01)
 """

--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -64,21 +64,9 @@ end
 # This can't be a simple alias, because `readCONTCAR()` needs to find a file name `CONTCAR`
 readCONTCAR(io::IO) = readPOSCAR(io)
 
-function readPOSCAR(filename)
-    # Append POSCAR if only a directory name is given
-    if last(filename) == '/'
-        filename = filename * "POSCAR"
-    end
-    open(readPOSCAR, filename)
-end
-
-function readCONTCAR(filename)
-    # Append POSCAR if only a directory name is given
-    if last(filename) == '/'
-        filename = filename * "CONTCAR"
-    end
-    open(readPOSCAR, filename)
-end
+# Append POSCAR/CONTCAR if only a directory name is given
+readPOSCAR(file) = open(readPOSCAR, isdir(file) ? joinpath(file, "POSCAR") : file)
+readCONTCAR(file) = open(readPOSCAR, isdir(file) ? joinpath(file, "CONTCAR") : file)
 
 readPOSCAR() = open(readPOSCAR, "POSCAR")
 readCONTCAR() = open(readPOSCAR, "CONTCAR")

--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -20,7 +20,7 @@ function readPOSCAR(io::IO)
     # Get the basis
     latt = let lns = [readline(io) for n in 1:3]
         # Get the vectors from the next three lines
-        vecs = [parse.(Float64, v) for v in split.(lns)]
+        vecs = sc * [parse.(Float64, v) for v in split.(lns)]
         # Convert to RealBasis and return
         RealBasis{3}(vecs)
     end

--- a/test/filetypes.jl
+++ b/test/filetypes.jl
@@ -19,6 +19,9 @@ end
     @test name.(atomtypes(poscar)) == ["Si", "Ir"]
     @test atomic_number.(atomtypes(poscar)) == [14, 77]
     @test natomtypes(poscar) == 2
+    # Test that file writing works correctly
+    writeCONTCAR(tmpdir, poscar)
+    @test readCONTCAR(tmpdir) == sort(poscar)
 end
 
 @testset "LAMMPS position data" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using LinearAlgebra, StaticArrays
 using Test, Aqua, Electrum
 
+tmpdir = mktempdir()
+
 Aqua.test_all(Electrum; project_toml_formatting=false)
 
 xsf = readXSF3D("files/test.xsf")


### PR DESCRIPTION
Now we have `writePOSCAR()` which writes data to a POSCAR file (by default to a file named `POSCAR`) and its corresponding function `writeCONTCAR()` which defaults to `CONTCAR` as the filename.

`writePOSCAR4()` has been reimplemented for compatibility, but may be deprecated in a future release and has been exported with the `@deprecate` macro.