### PR TITLE
Updating names of abinit file reading functions

### DIFF
--- a/docs/src/api/filetypes.md
+++ b/docs/src/api/filetypes.md
@@ -22,9 +22,9 @@ Electrum.writeXSF
 ### Reading
 
 ```@docs
-Electrum.read_abinit_density
-Electrum.read_abinit_potential
-Electrum.read_abinit_wavefunction
+Electrum.read_abinit_DEN
+Electrum.read_abinit_POT
+Electrum.read_abinit_WFK
 ```
 
 ## VASP files

--- a/docs/src/filetypes.md
+++ b/docs/src/filetypes.md
@@ -33,17 +33,17 @@ chosen to be written:
   * `_VHXC`: Sum of the Hartree and exchange-correlation potentials.
   * `_VXC`: Exchange-correlation potential. 
 
-Both density and potential files follow the same format. The `read_abinit_density()` and 
-`read_abinit_potential()` functions can be used to load in density and potential files.
+Both density and potential files follow the same format. The `read_abinit_DEN()` and 
+`read_abinit_POT()` functions can be used to load in density and potential files.
 
 ## Wavefunctions
 
-Wavefunctions can be read in by `read_abinit_wavefunction()`. This assumes that the wavefunction is
-stored by k-points (`istwfk` should be equal to `nkpt*1` in the input file).
+Wavefunctions can be read in by `read_abinit_WFK()`. This assumes that the wavefunction is stored by
+k-points (`istwfk` should be equal to `nkpt*1` in the input file).
 
-Because wavefunctions are large files, and reading them can be slow, `read_abinit_wavefunction()`
-will print `@info` messages for every k-point that is read in. This can be disabled by setting the
-keyword argument `quiet = true`.
+Because wavefunctions are large files, and reading them can be slow, `read_abinit_WFK()` will print
+`@info` messages for every k-point that is read in. This can be disabled by setting the keyword
+argument `quiet = true`.
 
 !!! info abinit 7.10.5 (header version 57) does not output the matrix associated with the k-point
 mesh used in the calculation (the kptrlatt field).

--- a/src/Electrum.jl
+++ b/src/Electrum.jl
@@ -138,9 +138,8 @@ export fftfreq, fft, ifft
 include("filetypes.jl")
 export readXYZ, writeXYZ, readXSF3D, readXSF, writeXSF, readCPcoeff, readCPgeo, readCPcell
 include("software/abinit.jl")
-export read_abinit_density, read_abinit_potential, read_abinit_wavefunction, read_abinit_DEN,
-    read_abinit_POT, read_abinit_anaddb_out, read_abinit_WFK, read_abinit_anaddb_in,
-    write_abinit_modes, read_abinit_anaddb_PHDOS
+export read_abinit_DEN, read_abinit_POT, read_abinit_WFK, read_abinit_anaddb_out,
+    read_abinit_anaddb_in, write_abinit_modes, read_abinit_anaddb_PHDOS
 include("software/vasp.jl")
 export readPOSCAR, readCONTCAR, writePOSCAR, writeCONTCAR, readWAVECAR, readDOSCAR, readPROCAR,
     get_fermi

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -6,9 +6,9 @@ precompile(supercell, (PeriodicAtomList, Any))
 precompile(readXSF, (AbstractString,))
 precompile(writeXSF, (AbstractString, CrystalWithDatasets))
 
-precompile(read_abinit_density, (AbstractString,))
-precompile(read_abinit_potential, (AbstractString,))
-precompile(read_abinit_wavefunction, (AbstractString,))
+precompile(read_abinit_DEN, (AbstractString,))
+precompile(read_abinit_POT, (AbstractString,))
+precompile(read_abinit_WFK, (AbstractString,))
 
 precompile(readPOSCAR, ())
 precompile(readCONTCAR, ())

--- a/src/software/abinit.jl
+++ b/src/software/abinit.jl
@@ -648,7 +648,7 @@ function read_abinit_datagrids(
     return rho
 end
 
-function read_abinit_density(io::IO)
+function read_abinit_DEN(io::IO)
     # Get the header from the file
     header = read_abinit_header(io)
     # Get the type of the datagrid (set by cplex in the header)
@@ -685,9 +685,9 @@ with explicit treatment of spin will return spin densities.
 
 Depending on the value of `cplex`, the datagrid(s) returned may be real or complex-valued.
 """
-read_abinit_density(filename) = open(read_abinit_density, filename)
+read_abinit_DEN(filename) = open(read_abinit_DEN, filename)
 
-function read_abinit_potential(io::IO)
+function read_abinit_POT(io::IO)
     # Get the header from the file
     header = read_abinit_header(io)
     # Get the type of the datagrid (set by cplex in the header)
@@ -728,9 +728,9 @@ explicit treatment of spin will return spin-dependent potentials.
 
 Depending on the value of `cplex`, the datagrid(s) returned may be real or complex-valued.
 """
-read_abinit_potential(filename) = open(read_abinit_potential, filename)
+read_abinit_POT(filename) = open(read_abinit_POT, filename)
 
-function read_abinit_wavefunction(io::IO; quiet = false)
+function read_abinit_WFK(io::IO; quiet = false)
     # Get the header from the file
     header = read_abinit_header(io)
     # Get the reciprocal lattice
@@ -789,7 +789,7 @@ function read_abinit_wavefunction(io::IO; quiet = false)
 end
 
 """
-    read_abinit_wavefunction(file)
+    read_abinit_WFK(file)
         -> CrystalWithDatasets{3,String,PlanewaveWavefunction{3,Complex{Float64}}}
 
 Reads a FORTRAN binary formatted abinit wavefunction file.
@@ -804,11 +804,7 @@ By default, the function is verbose, with output printed for every k-point parse
 size of the wavefunction files. If this behavior is undesirable, the `quiet` keyword argument may be
 set to `true`.
 """
-read_abinit_wavefunction(file; quiet = false) = open(f -> read_abinit_wavefunction(f; quiet), file)
-
-const read_abinit_DEN = read_abinit_density
-const read_abinit_POT = read_abinit_potential
-const read_abinit_WFK = read_abinit_wavefunction
+read_abinit_WFK(filename; quiet = false) = open(f -> read_abinit_WFK(f; quiet), filename)
 
 """
     read_abinit_anaddb_out(filename::AbstractString)

--- a/src/software/abinit.jl
+++ b/src/software/abinit.jl
@@ -648,6 +648,21 @@ function read_abinit_datagrids(
     return rho
 end
 
+"""
+    read_abinit_density(file)
+        -> CrystalWithDatasets{3,String,RealSpaceDataGrid{3,Float64}}
+
+Reads a FORTRAN binary formatted abinit density file. By default, abinit density files will have
+the suffix `DEN`, but no assumptions are made about suffixes.
+
+The header is used to automatically determine the file format, so this should read in any abinit
+density output (provided a function exists to parse that header).
+
+The number of datasets returned depends on the value of `nsppol` in the header, as calculations
+with explicit treatment of spin will return spin densities.
+
+Depending on the value of `cplex`, the datagrid(s) returned may be real or complex-valued.
+"""
 function read_abinit_DEN(io::IO)
     # Get the header from the file
     header = read_abinit_header(io)
@@ -670,23 +685,26 @@ function read_abinit_DEN(io::IO)
     return CrystalWithDatasets{3,String,RealSpaceDataGrid{3,T}}(Crystal(header), data)
 end
 
-"""
-    read_abinit_density(file)
-        -> CrystalWithDatasets{3,String,RealSpaceDataGrid{3,Float64}}
+read_abinit_DEN(filename) = open(read_abinit_DEN, filename)
 
-Reads a FORTRAN binary formatted abinit density file. By default, abinit density files will have
-the suffix `DEN`, but no assumptions are made about suffixes.
+"""
+    read_abinit_potential(file)
+        -> CrystalWithDatasets{3,String,RealSpaceDataGrid{3,T<:Number}}
+
+Reads a FORTRAN binary formatted abinit potential file.
+
+By default, abinit potential files will end in `POT` for the external potential, `VHA` for the 
+Hartree potential, `VXC` for the exchange-correlation potential, and `VHXC` for the sum of both the
+Hartree and exchange-correlation potentials.
 
 The header is used to automatically determine the file format, so this should read in any abinit
 density output (provided a function exists to parse that header).
 
-The number of datasets returned depends on the value of `nsppol` in the header, as calculations
-with explicit treatment of spin will return spin densities.
+The number of datasets returned depends on the value of `nsppol` in the header, as calculations with
+explicit treatment of spin will return spin-dependent potentials.
 
 Depending on the value of `cplex`, the datagrid(s) returned may be real or complex-valued.
 """
-read_abinit_DEN(filename) = open(read_abinit_DEN, filename)
-
 function read_abinit_POT(io::IO)
     # Get the header from the file
     header = read_abinit_header(io)
@@ -710,26 +728,24 @@ function read_abinit_POT(io::IO)
     return CrystalWithDatasets{3,String,RealSpaceDataGrid{3,T}}(Crystal(header), data)
 end
 
+read_abinit_POT(filename) = open(read_abinit_POT, filename)
+
 """
-    read_abinit_potential(file)
-        -> CrystalWithDatasets{3,String,RealSpaceDataGrid{3,T}} where T<:Union{Float64,ComplexF64}
+    read_abinit_WFK(file)
+        -> CrystalWithDatasets{3,String,PlanewaveWavefunction{3,Complex{Float64}}}
 
-Reads a FORTRAN binary formatted abinit potential file.
+Reads a FORTRAN binary formatted abinit wavefunction file.
 
-By default, abinit potential files will end in `POT` for the external potential, `VHA` for the 
-Hartree potential, `VXC` for the exchange-correlation potential, and `VHXC` for the sum of both the
-Hartree and exchange-correlation potentials.
+By default, abinit returns wavefunction data in `Complex{Float64}` entries, and this is maintained
+in the return type.
 
 The header is used to automatically determine the file format, so this should read in any abinit
 density output (provided a function exists to parse that header).
 
-The number of datasets returned depends on the value of `nsppol` in the header, as calculations with
-explicit treatment of spin will return spin-dependent potentials.
-
-Depending on the value of `cplex`, the datagrid(s) returned may be real or complex-valued.
+By default, the function is verbose, with output printed for every k-point parsed, due to the large
+size of the wavefunction files. If this behavior is undesirable, the `quiet` keyword argument may be
+set to `true`.
 """
-read_abinit_POT(filename) = open(read_abinit_POT, filename)
-
 function read_abinit_WFK(io::IO; quiet = false)
     # Get the header from the file
     header = read_abinit_header(io)
@@ -788,22 +804,6 @@ function read_abinit_WFK(io::IO; quiet = false)
     )
 end
 
-"""
-    read_abinit_WFK(file)
-        -> CrystalWithDatasets{3,String,PlanewaveWavefunction{3,Complex{Float64}}}
-
-Reads a FORTRAN binary formatted abinit wavefunction file.
-
-By default, abinit returns wavefunction data in `Complex{Float64}` entries, and this formatting is
-maintained in the return type.
-
-The header is used to automatically determine the file format, so this should read in any abinit
-density output (provided a function exists to parse that header).
-
-By default, the function is verbose, with output printed for every k-point parsed, due to the large
-size of the wavefunction files. If this behavior is undesirable, the `quiet` keyword argument may be
-set to `true`.
-"""
 read_abinit_WFK(filename; quiet = false) = open(f -> read_abinit_WFK(f; quiet), filename)
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,8 +6,8 @@ tmpdir = mktempdir()
 Aqua.test_all(Electrum; project_toml_formatting=false)
 
 xsf = readXSF3D("files/test.xsf")
-v80_den = read_abinit_density("files/Sc_eq_o_DEN")
-v80_wfk = read_abinit_wavefunction("files/Sc_eq_o_WFK")
+v80_den = read_abinit_DEN("files/Sc_eq_o_DEN")
+v80_wfk = read_abinit_WFK("files/Sc_eq_o_WFK")
 wavecar = readWAVECAR("files/WAVECAR")
 # These two have the same data. Well...almost...
 poscar = readPOSCAR("files/POSCAR")


### PR DESCRIPTION
Until now there were pairs of functions that did the same thing: `read_abinit_density()` and `read_abinit_DEN()`, `read_abinit_potential()` and `read_abinit_POT()`, and `read_abinit_wavefunction()` and `read_abinit_WFK()`.

My future design plan is to have functions like `read_abinit_density()` return only the associated datagrid, and `read_abinit_DEN()` return the datagrid as part of a `CrystalWithDatasets` (or perhaps a similar future type that replaces it). So the aliasing of function names is being dropped.

@xamberl I'm going to loop you in on this