### PR TITLE
Use Hartree atomic units everywhere

### DIFF
--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -13,7 +13,7 @@ The `AbstractBasis` type contains two subtypes, `RealBasis` and `ReciprocalBasis
 used to represent the basis vectors of a crystal.
 
 `AbstractBasis` types use the following conventions:
-  * The units are assumed to be angstroms or inverse angstroms.
+  * The units are assumed to be bohr for lengths or rad bohr⁻¹ for inverse.
   * Conversion between the two involve a factor of 2π (multiplication for the `RealBasis` >  
 `ReciprocalBasis` conversion, and vice versa).
 
@@ -54,9 +54,9 @@ or an atomic number of zero. These are useful for marking important positions in
 ## `CartesianAtomPosition` and `FractionalAtomPosition`
 
 These types are combinations of a `NamedAtom` and an `SVector`. A `CartesianAtomPosition` describes
-an atomic coordinate in the default length units (angstroms), and a `FractionalAtomPosition`
-describes an atomic coordinate with respect to a crystal lattice basis, which is not included with
-the coordinate.
+an atomic coordinate in the default length units (bohr), and a `FractionalAtomPosition` describes
+an atomic coordinate with respect to a crystal lattice basis, which is not included with the
+coordinate.
 
 ## `AtomList` and `PeriodicAtomList`
 

--- a/src/Electrum.jl
+++ b/src/Electrum.jl
@@ -60,18 +60,30 @@ const TOL_DEF = 1e-8
 """
     Electrum.BOHR2ANG
 
-Converts lengths in bohr to angstrom
+Converts lengths in bohr to angstrom.
 """
-const BOHR2ANG = 0.52917720859
+const BOHR2ANG = 0.52917721090380
 
-#= Units of these two constants should be energy^-1 * length^-2
 """
-    Electrum.CABINIT
+    Electrum.ANG2BOHR
 
-The value of 2m_e/ħ^2 as used in abinit (hartree^-1 * angstrom^-2).
+Converts lengths in angstrom to bohr.
 """
-const CABINIT = 7.142129652186264
-=#
+const ANG2BOHR = 1.8897261246229133
+
+"""
+    Electrum.HARTREE2EV
+
+Converts energies in hartree to electron-volts.
+"""
+const HARTREE2EV = 27.21138624598853
+
+"""
+    Electrum.EV2HARTREE
+
+Converts energies in electron-volts to hartree.
+"""
+const EV2HARTREE = 0.03674932217565428
 
 """
     Electrum.CVASP

--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -79,7 +79,7 @@ end
     CartesianAtomPosition{D}
 
 Describes an absolute atomic position. The coordinate in the `pos` field is assumed to be given in
-angstroms.
+bohr.
 
 Occupancy information is provided in the `occ` field. Note that no checking is done to ensure that
 the occupancy is a reasonable value.

--- a/src/data/realspace.jl
+++ b/src/data/realspace.jl
@@ -49,18 +49,14 @@ end
 """
     volume(g::RealSpaceDataGrid) -> Float64
 
-Gets the crystal volume associated with a `RealSpaceDataGrid`.
-
-By default, units are assumed to be cubic angstroms.
+Gets the crystal volume associated with a `RealSpaceDataGrid`. Units are assumed to be bohr³.
 """
 volume(g::RealSpaceDataGrid) = volume(basis(g))
 
 """
     voxelsize(g::RealSpaceDataGrid) -> Float64
 
-Gets the size of a single voxel of a `RealSpaceDataGrid`.
-
-By default, units are assumed to be cubic angstroms.
+Gets the size of a single voxel of a `RealSpaceDataGrid`. Units are assumed to be bohr³.
 """
 voxelsize(g::RealSpaceDataGrid) = volume(g) / length(g)
 

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -25,7 +25,7 @@ lattice_sanity_check(v::AbstractVector{<:AbstractVector{<:Real}}) = lattice_sani
 """
     RealBasis{D} <: AbstractBasis{D}
 
-A set of real space basis vectors, assumed to be in angstroms.
+A set of real space basis vectors, assumed to be in bohr.
 """
 struct RealBasis{D} <: AbstractBasis{D}
     vs::SVector{D,SVector{D,Float64}}
@@ -42,7 +42,7 @@ end
 """
     ReciprocalBasis{D} <: AbstractBasis{D}
 
-A set of reciprocal space basis vectors, assumed to be in inverse angstroms.
+A set of reciprocal space basis vectors, assumed to be in rad*bohr⁻¹.
 """
 struct ReciprocalBasis{D} <: AbstractBasis{D}
     vs::SVector{D,SVector{D,Float64}}
@@ -175,19 +175,19 @@ Returns the lengths of the constituent vectors in a matrix representing cell vec
 cell_lengths(M::AbstractMatrix) = [norm(M[:,n]) for n = 1:size(M,2)]
 
 """
-    lengths(b::AbstractBasis) -> Vector{Float64}
+    lengths(b::AbstractBasis{D}) -> SVector{D,Float64}
 
-Returns the lengths of the basis vectors.
+Returns the lengths of the basis vectors. The units correspond to the type of the basis vectors: for
+`RealBasis` the units are bohr, and for `ReciprocalBasis` the units are rad*bohr⁻¹.
 """
 lengths(b::AbstractBasis{D}) where D = SVector{D}(norm(v) for v in b)
-# Get the vector lengths for anything that has a defined basis
 
 """
     lengths(x) -> Float64
 
-Calculate the lengths of the basis vectors associated with `x`. These will be real space lengths
-(assumed to be in angstroms) for real space data, and reciprocal space lengths for reciprocal space
-data.
+Calculate the lengths of the basis vectors associated with `x`. The units correspond to the type of
+the basis vectors: for `RealBasis` the units are bohr, and for `ReciprocalBasis` the units are
+rad*bohr⁻¹.
 """
 lengths(x) = lengths(basis(x))
 
@@ -203,15 +203,16 @@ cell_volume(M::AbstractMatrix) = abs(det(M))
     volume(b::AbstractBasis) -> Float64
 
 Returns the volume of a unit cell defined by a matrix. This volume does not carry the sign (negative
-for cells that do not follow the right hand rule).
+for cells that do not follow the right hand rule). The units correspond to the type of the basis 
+vectors: for `RealBasis` the units are bohr³, and for `ReciprocalBasis` the units are rad³*bohr⁻³.
 """
 volume(b::AbstractBasis) = cell_volume(matrix(b))
 
 """
     volume(x) -> Float64
 
-Calculate the volume of the basis associated with `x`. This will be a real space volume (assumed to
-be in cubic angstroms) for real space data, and reciprocal space lengths for reciprocal space data.
+Calculate the volume of the basis associated with `x`. The units correspond to the type of the basis 
+vectors: for `RealBasis` the units are bohr³, and for `ReciprocalBasis` the units are rad³*bohr⁻³.
 """
 volume(x) = volume(basis(x))
 

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -366,7 +366,7 @@ The functionality implemented here was taken from WaveTrans:
 https://www.andrew.cmu.edu/user/feenstra/wavetrans/
 """
 # Assume that the basis vectors are defined in reciprocal space (??)
-function maxHKLindex(b::AbstractBasis{3}, ecut::Real; c = CVASP)
+function maxHKLindex(b::AbstractBasis{3}, ecut::Real; c = 2)
     return maxHKLindex(matrix(ReciprocalBasis(b)), ecut, c = c)
 end
 

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -340,7 +340,7 @@ end
 # TODO: Update and document this function a bit more.
 # It works, but that really isn't enough for me.
 # I think this was pulled directly from the WaveTrans source code
-function maxHKLindex(M::AbstractMatrix{<:Real}, ecut::Real; c = CVASP)
+function maxHKLindex(M::AbstractMatrix{<:Real}, ecut::Real; c = 2)
     # I think the parts below convert a set of basis vectors into their reciprocals
     #----------------------------------------------------------------------------------------------#
     cosines = cell_angles_cos(M)

--- a/src/show.jl
+++ b/src/show.jl
@@ -81,8 +81,8 @@ function basis_string(
     ]
 end
 
-basis_string(b::RealBasis, kwargs...) = basis_string(matrix(b), unit="Å", kwargs...)
-basis_string(b::ReciprocalBasis, kwargs...) = basis_string(matrix(b), unit="Å⁻¹", kwargs...)
+basis_string(b::RealBasis, kwargs...) = basis_string(matrix(b), unit="bohr", kwargs...)
+basis_string(b::ReciprocalBasis, kwargs...) = basis_string(matrix(b), unit="rad*bohr⁻¹", kwargs...)
 
 """
     Electrum.printbasis([io::IO = stdout], b; kwargs...)

--- a/src/show.jl
+++ b/src/show.jl
@@ -52,11 +52,11 @@ julia> M = 3.5 * [0 1 1; 1 0 1; 1 1 0]
  3.5  0.0  3.5
  3.5  3.5  0.0
 
-julia> Electrum.basis_string(M, letters=true, length=true, unit="Å")
+julia> Electrum.basis_string(M, letters=true, length=true, unit="bohr")
 3-element Vector{String}:
- "  a: [  0.000000  3.500000  3.500000 ]   (4.949747 Å)"
- "  b: [  3.500000  0.000000  3.500000 ]   (4.949747 Å)"
- "  c: [  3.500000  3.500000  0.000000 ]   (4.949747 Å)"
+ "  a: [  0.000000  3.500000  3.500000 ]   (4.949747 bohr)"
+ "  b: [  3.500000  0.000000  3.500000 ]   (4.949747 bohr)"
+ "  c: [  3.500000  3.500000  0.000000 ]   (4.949747 bohr)"
 ```
 """
 function basis_string(
@@ -108,8 +108,8 @@ function printbasis(io::IO, M::AbstractMatrix{<:Real}; letters=true, unit="", pa
     print(io, join(" "^pad .* s, "\n"))
 end
 
-printbasis(io::IO, b::RealBasis; kwargs...) = printbasis(io, matrix(b), unit="Å"; kwargs...)
-printbasis(io::IO, b::ReciprocalBasis; kw...) = printbasis(io, matrix(b), unit="Å⁻¹"; kw...)
+printbasis(io::IO, b::RealBasis; kwargs...) = printbasis(io, matrix(b), unit="bohr"; kwargs...)
+printbasis(io::IO, b::ReciprocalBasis; kw...) = printbasis(io, matrix(b), unit="rad*bohr⁻¹"; kw...)
 printbasis(io::IO, a; kwargs...) = printbasis(io, basis(a); kwargs...)
 printbasis(a; kwargs...) = printbasis(stdout, a; kwargs...)
 
@@ -125,7 +125,7 @@ function atom_string(a::AbstractAtomPosition; name=true, num=true)
         rpad(string(a.atom.num), 4)^num,
         rpad(a.atom.name, 6)^name,
         vector_string(a.pos),
-        "  Å"^(a isa CartesianAtomPosition),
+        "  bohr"^(a isa CartesianAtomPosition),
         "  (occupancy $(a.occ))"^(a.occ != 1)
     )
 end
@@ -198,8 +198,8 @@ function Base.show(io::IO, ::MIME"text/plain", g::RealSpaceDataGrid)
     dimstring = join(string.(size(g)), "×") * " "
     println(io, dimstring, typeof(g), " with real space basis vectors:")
     printbasis(io, g)
-    @printf(io, "\nCell volume: %16.10f Å", volume(g))
-    @printf(io, "\nVoxel size:  %16.10f Å", voxelsize(g))
+    @printf(io, "\nCell volume: %16.10f bohr", volume(g))
+    @printf(io, "\nVoxel size:  %16.10f bohr³", voxelsize(g))
 end
 
 #---Types from data/reciprocalspace.jl-------------------------------------------------------------#
@@ -225,7 +225,7 @@ function Base.show(io::IO, ::MIME"text/plain", g::HKLData)
         print(io, "\n  ", '`' + n, ":", )
         sz = size(g)[n]
         @printf(
-            io, "%12.6f Å⁻¹ to %.6f Å⁻¹",
+            io, "%12.6f rad*bohr⁻¹ to %.6f rad*bohr⁻¹",
             -div(sz-1, 2) * lengths(basis(g))[n],
             div(sz, 2) * lengths(basis(g))[n],
         )
@@ -284,10 +284,10 @@ function Base.show(io::IO, ::MIME"text/plain", xtal::Crystal{D}) where D
     println(io, typeof(xtal), " (", formula_string(xtal), ", space group ", xtal.sgno, "): ")
     # Print basis vectors
     println(io, "\n  Primitive basis vectors:")
-    printbasis(io, xtal, pad=2, unit="Å")
+    printbasis(io, xtal, pad=2, unit="bohr")
     if xtal.transform != SMatrix{D,D,Float64}(LinearAlgebra.I)
         println(io, "\n\n  Conventional basis vectors:")
-        printbasis(io, basis(xtal) * xtal.transform, pad=2, unit="Å")
+        printbasis(io, basis(xtal) * xtal.transform, pad=2, unit="bohr")
     end
     # TODO: Add in more info about atomic positions, space group
     println(io, "\n\n  ", length(xtal.atoms), " atomic positions:")

--- a/src/software/abinit.jl
+++ b/src/software/abinit.jl
@@ -180,7 +180,7 @@ symrel_to_sg(h::ABINITHeader) = symrel_to_sg(h.symrel)
 function Crystal(h::ABINITHeader)
     atomlist = PeriodicAtomList(
         # Convert to angstroms
-        RealBasis{3}(BOHR2ANG*h.rprimd),
+        RealBasis{3}(h.rprimd),
         FractionalAtomPosition.(
             Int.(h.znucltypat[h.typat]),
             h.xred
@@ -750,12 +750,12 @@ function read_abinit_WFK(io::IO; quiet = false)
     # Get the header from the file
     header = read_abinit_header(io)
     # Get the reciprocal lattice
-    rlatt = convert(ReciprocalBasis, RealBasis(header.rprimd)) / BOHR2ANG
+    rlatt = convert(ReciprocalBasis, RealBasis(header.rprimd))
     # Get the minimum and maximum HKL values needed
     # Units for c (2*m_e/ħ^2) are hartree^-1 bohr^-2
     # this should affect only the size of the preallocated arrays
     bounds = SVector{3,UnitRange{Int}}(
-        -g:g for g in maxHKLindex(rlatt * BOHR2ANG, header.ecut, c=2)
+        -g:g for g in maxHKLindex(rlatt, header.ecut)
     )
     @debug string(
         "hklbounds: ", bounds, "\n",

--- a/src/software/abinit.jl
+++ b/src/software/abinit.jl
@@ -179,7 +179,6 @@ symrel_to_sg(h::ABINITHeader) = symrel_to_sg(h.symrel)
 
 function Crystal(h::ABINITHeader)
     atomlist = PeriodicAtomList(
-        # Convert to angstroms
         RealBasis{3}(h.rprimd),
         FractionalAtomPosition.(
             Int.(h.znucltypat[h.typat]),

--- a/src/software/vasp.jl
+++ b/src/software/vasp.jl
@@ -200,7 +200,7 @@ function readWAVECAR(io::IO; quiet = false)
     # Reciprocal lattice vectors
     rlatt = convert(ReciprocalBasis, RealBasis{3}([read(io, Float64) for a = 1:3, b = 1:3]))
     # Get HKL coefficient bounds (as done in WaveTrans)
-    hklbounds = SVector{3,UnitRange{Int}}(-g:g for g in maxHKLindex(rlatt, ecut))
+    hklbounds = SVector{3,UnitRange{Int}}(-g:g for g in maxHKLindex(rlatt, ecut, c = CVASP))
     # Bare wavefunction to be filled
     wf = PlanewaveWavefunction{3,Complex{Float32}}(rlatt, nspin, nkpt, nband, hklbounds...)
     # Loop through the spins

--- a/src/types.jl
+++ b/src/types.jl
@@ -32,7 +32,7 @@ end
 Supertype for sets of basis vectors in `D` dimensions.
 
 This supertype includes the `RealBasis{D}` and `ReciprocalBasis{D}` types, which explicitly 
-indicate their units (assumed to be either angstroms or inverse angstroms).
+indicate their units (assumed to be either bohr or rad*bohr⁻¹).
 
 Members of `AbstractBasis` must implement the following checks:
   * That the basis vectors are linearly independent and form a right-handed coordinate system, 

--- a/test/filetypes.jl
+++ b/test/filetypes.jl
@@ -21,7 +21,9 @@ end
     @test natomtypes(poscar) == 2
     # Test that file writing works correctly
     writeCONTCAR(tmpdir, poscar)
-    @test readCONTCAR(tmpdir) == sort(poscar)
+    contcar = readCONTCAR(tmpdir)
+    @test basis(contcar) ≈ basis(poscar)
+    @test contcar.atoms == sort(poscar).atoms
 end
 
 @testset "LAMMPS position data" begin

--- a/test/filetypes.jl
+++ b/test/filetypes.jl
@@ -27,5 +27,5 @@ end
 @testset "LAMMPS position data" begin
     # This is going to suffer from floating point errors/parsing differences
     @test all(isapprox.(displacement.(lammps.atoms), displacement.(poscar.atoms), atol=1e-6))
-    @test isapprox(basis(lammps), basis(poscar), atol=1e-6)
+    @test isapprox(basis(lammps), basis(poscar), atol=1e-6 * Electrum.ANG2BOHR)
 end


### PR DESCRIPTION
I've converted `RealBasis` and `ReciprocalBasis` to using bohr as the default length unit (and rad\*bohr⁻¹ for inverse length). By default, energy units are assumed to be in Hartree. (Packages like VASP that don't use Hartree atomic units by default have their inputs converted to match the package's conventions)