### PR TITLE
More testing/functionality for abinit headers

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -327,3 +327,10 @@ function Base.show(io::IO, ::MIME"text/plain", h::ABINITHeader)
         end
     end
 end
+
+function Base.show(io::IO, ::MIME"text/plain", pspinfo::ABINITPseudopotentialInfo)
+    println(io, typeof(pspinfo), ":")
+    println(io, "  Title:  \"", pspinfo.title)
+    println(io, "  Atom:    ", pspinfo.znuclpsp, " (", ELEMENTS[Int(pspinfo.znuclpsp)], ")")
+    println(io, "  Charge:  ", pspinfo.zionpsp)
+end

--- a/src/software/abinit.jl
+++ b/src/software/abinit.jl
@@ -580,11 +580,6 @@ Reads the header of an ABINIT output file, automatically determining the format 
 the first few digits.
 """
 function read_abinit_header(io::IO)
-    # Select which function to use based on the headform value
-    fdict = Dict{Int, Function}(
-        57 => read_abinit_header_57,
-        80 => read_abinit_header_80,
-    )
     # Get the info stored in the header
     (codvsn, headform, fform) = get_abinit_version(io)
     # @debug string("abinit version ", codvsn, " (header version ", headform, ")")

--- a/src/software/abinit.jl
+++ b/src/software/abinit.jl
@@ -149,6 +149,11 @@ Base.@kwdef mutable struct ABINITHeader
     pawdata::Matrix{Matrix{Float64}} = Matrix{Matrix{Float64}}(undef, 0, 0)    # size nspden*natom
 end
 
+# Equality definition
+function Base.:(==)(h1::T, h2::T) where T<:ABINITHeader
+    return all(getfield(h1, s) == getfield(h2, s) for s in fieldnames(T))
+end
+
 # Index notation for this thing, just in case that's easier
 Base.getindex(h::ABINITHeader, name::Symbol) = getfield(h, name)
 Base.setindex!(h::ABINITHeader, x, name::Symbol) = setfield!(x, h, name)

--- a/src/software/abinit.jl
+++ b/src/software/abinit.jl
@@ -15,13 +15,6 @@ struct ABINITPseudopotentialInfo
     md5_pseudos::String      # Really, not as a UInt?
 end
 
-function Base.show(io::IO, ::MIME"text/plain", pspinfo::ABINITPseudopotentialInfo)
-    println(io, typeof(pspinfo), ":")
-    println(io, "  Title:  \"", pspinfo.title)
-    println(io, "  Atom:    ", pspinfo.znuclpsp, " (", ELEMENTS[Int(pspinfo.znuclpsp)], ")")
-    println(io, "  Charge:  ", pspinfo.zionpsp)
-end
-
 # Making this thing mutable is probably the best idea here
 # That way we can initialize the struct and then update all the data
 """

--- a/src/software/abinit.jl
+++ b/src/software/abinit.jl
@@ -156,7 +156,7 @@ end
 
 # Index notation for this thing, just in case that's easier
 Base.getindex(h::ABINITHeader, name::Symbol) = getfield(h, name)
-Base.setindex!(h::ABINITHeader, x, name::Symbol) = setfield!(x, h, name)
+Base.setindex!(h::ABINITHeader, x, name::Symbol) = setfield!(h, name, x)
 
 #=
 """

--- a/src/software/abinit.jl
+++ b/src/software/abinit.jl
@@ -600,6 +600,8 @@ function read_abinit_header(io::IO)
     return header
 end
 
+read_abinit_header(filename) = open(read_abinit_header, filename)
+
 """
     Electrum.read_abinit_datagrids(T, io, nspden, ngfft) -> Vector{Matrix{T}}
 

--- a/src/software/abinit.jl
+++ b/src/software/abinit.jl
@@ -160,6 +160,7 @@ end
 Base.getindex(h::ABINITHeader, name::Symbol) = getfield(h, name)
 Base.setindex!(h::ABINITHeader, x, name::Symbol) = setfield!(x, h, name)
 
+#=
 """
     Electrum.symrel_to_sg(symrel::AbstractVector{<:AbstractMatrix{<:Integer}}) -> Int
 
@@ -174,8 +175,8 @@ function symrel_to_sg(symrel::AbstractVector{<:AbstractMatrix{<:Integer}})
     twofold = [diagm([-1, -1, -1])]
     return 1 # for now
 end
-
 symrel_to_sg(h::ABINITHeader) = symrel_to_sg(h.symrel)
+=#
 
 function Crystal(h::ABINITHeader)
     atomlist = PeriodicAtomList(

--- a/test/filetypes.jl
+++ b/test/filetypes.jl
@@ -13,6 +13,10 @@ end
         getfield(header_den, s) == getfield(header_wfk, s)
         for s in fieldnames(Electrum.ABINITHeader)[4:end]
     )
+    @test header_den != header_wfk
+    @test header_den[:fform] === header_den.fform
+    header_wfk[:fform] = header_den[:fform]
+    @test header_den == header_wfk
     # Check that the correct FFT grid size is read
     @test size(den) == (24, 24, 36)
     # Check that there's 1 spin, 4 k-points, and 8 bands

--- a/test/filetypes.jl
+++ b/test/filetypes.jl
@@ -8,6 +8,11 @@ end
 @testset "abinit outputs" begin
     den = v80_den["density_total"]
     wfk = v80_wfk["wavefunction"]
+    # fform differs between the two - perhaps this could be useful later
+    @test all(
+        getfield(header_den, s) == getfield(header_wfk, s)
+        for s in fieldnames(Electrum.ABINITHeader)[4:end]
+    )
     # Check that the correct FFT grid size is read
     @test size(den) == (24, 24, 36)
     # Check that there's 1 spin, 4 k-points, and 8 bands

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,8 @@ tmpdir = mktempdir()
 Aqua.test_all(Electrum; project_toml_formatting=false)
 
 xsf = readXSF3D("files/test.xsf")
+header_den = Electrum.read_abinit_header("files/Sc_eq_o_DEN")
+header_wfk = Electrum.read_abinit_header("files/Sc_eq_o_WFK")
 v80_den = read_abinit_DEN("files/Sc_eq_o_DEN")
 v80_wfk = read_abinit_WFK("files/Sc_eq_o_WFK")
 wavecar = readWAVECAR("files/WAVECAR")


### PR DESCRIPTION
Although `Electrum.read_abinit_header()` is not exported, it is now easier to use, as it accepts a generic file name/path argument as well as an I/O handle. I've also defined equality for `Electrum.ABINITHeader` objects, and fixed `setindex!()` for them.