### PR TITLE
Fixed definition of the `lengths()` function for basis vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+ -  `lengths(::LatticeBasis)` now correctly uses a column iterator to return the length values
+
 ## [0.1.0] - 2023-05-25
 
 Initial release of Electrum.jl
 
+[Unreleased]: https://github.com/brainandforce/Electrum.jl
 [0.1.0]: https://github.com/brainandforce/Electrum.jl/releases/tag/v0.0.1

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -187,7 +187,7 @@ LinearAlgebra.det(b::LatticeBasis) = det(b.matrix)
 Returns the lengths of the basis vectors. The units correspond to the type of the basis vectors: for
 `RealBasis` the units are bohr, and for `ReciprocalBasis` the units are rad*bohr⁻¹.
 """
-lengths(b::LatticeBasis{S,D}) where {S,D} = SVector{D}(norm(v) for v in b)
+lengths(b::LatticeBasis{S,D}) where {S,D} = SVector{D}(norm(v) for v in eachcol(b))
 
 """
     volume(b::LatticeBasis) -> Real

--- a/test/lattices.jl
+++ b/test/lattices.jl
@@ -15,4 +15,6 @@
     # Type promotion
     @test promote_type(RealBasis{3,Int64}, RealBasis{3,Float32}) === RealBasis{3,Float32}
     @test promote_type(RealBasis{3,Int64}, ReciprocalBasis{3,Float32}) === SMatrix{3,3,Float32,9}
+    # Metrics
+    @test all(x == Electrum.ANG2BOHR for x in lengths(b))
 end


### PR DESCRIPTION
This is intended to fix #169. In general, I may have to keep an eye on how I implemented older iteration through basis vectors, as the iteration specification has changed.