### PR TITLE
Support for abinit 9.10.1 outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+  - Support for reading abinit 9.10.1 binary outputs
+
+### Changed
+  - `Electrum.get_abinit_version(::IO)` now strips spaces before constructing the version string
+
 ## [0.1.5]: 2023-07-02
 
 ### Changed

--- a/src/software/abinit.jl
+++ b/src/software/abinit.jl
@@ -225,6 +225,9 @@ end
 
 Reads in an abinit header from the outputs of calculations made by versions up to 7.10. These files
 will contain a `headform` value of 57.
+
+This function has been tested with outputs from abinit 7.10.5 using calculation data generated with
+both norm-conserving pseudopotentials and PAW atomic data.
 """
 function read_abinit_header_57(io::IO)
     # Variable names in this function correspond to names given here:
@@ -384,8 +387,11 @@ end
 """
     Electrum.read_abinit_header_80(io::IO) -> ABINITHeader
 
-Reads in an abinit header from the outputs of calculations made by versions up to 8.10. These files
+Reads in an abinit header from the outputs of calculations made by versions up to 9.10. These files
 will contain a `headform` value of 80.
+
+This function has been tested with outputs from abinit 8.10.3 and abinit 9.10.1 using calculation
+data generated with norm-conserving pseudopotentials.
 """
 function read_abinit_header_80(io::IO)
     # Variable names in this function correspond to names given here:

--- a/src/software/abinit.jl
+++ b/src/software/abinit.jl
@@ -212,7 +212,7 @@ Gets the ABINIT version information from a calculation output header.
 function get_abinit_version(io::IO)
     # Get the size of the first data entry
     sz = read(io, Int32)
-    codvsn = VersionNumber(String(read(io, sz - 8)))
+    codvsn = VersionNumber(strip(String(read(io, sz - 8))))
     headform = read(io, Int32)
     fform = read(io, Int32)
     # Skip to the next field - assume the next thing to happen is one of the header reading methods


### PR DESCRIPTION
I performed some norm-conserving pseudopotential calculations with abinit 9.10.1 and fixed a bug which now enables support for that version. Previously, Electrum only officially had support for abinit 7.10.5 and 8.10.3.