### PR TITLE
TOML writing support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
   - Support for reading abinit 9.10.1 binary outputs
+  - Support for writing TOML files (optional thanks to Requires.jl dependency)
 
 ### Changed
   - `Electrum.get_abinit_version(::IO)` now strips spaces before constructing the version string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ The developers would like to wish you a happy [Tau Day](https://tauday.com/)!
 ### Fixed
   - Reference to old field name for previous data grid type was corrected
 
+### Changed
+ -  Added dependency on Requires.jl for optional features
+
 ## [0.1.2]: 2023-06-26
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NormalForms = "109d20d8-9763-411c-9b60-7eb2a068657f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -17,11 +17,13 @@ ComputedFieldTypes = "1"
 FFTW = "1"
 NormalForms = "0.1"
 StaticArrays = "1"
+Requires = "1"
 julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [targets]
-test = ["Aqua", "Test"]
+test = ["Aqua", "Test", "TOML"]

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Electrum.jl is tested against the most recent LTS release (currently 1.6.7).
      + XCrysDen XSF
      + XYZ files
      + VASP POSCAR
+     + TOML files
 * Operations on datagrids:
      + Standard arithmetic operations: addition, subtraction, multiplication, division, negation...
      + Broadcasting of any Julia operation with dot syntax

--- a/docs/src/api/filetypes.md
+++ b/docs/src/api/filetypes.md
@@ -5,7 +5,6 @@
 ### Reading
 ```@docs
 Electrum.readXYZ
-Electrum.readXSF
 Electrum.readCPcoeff
 Electrum.readCPgeo
 Electrum.readCPcell
@@ -14,6 +13,18 @@ Electrum.readCPcell
 ### Writing
 ```@docs
 Electrum.writeXYZ
+Electrum.writeTOML
+```
+
+## XCrysDen XSF files
+
+### Reading
+```@docs
+Electrum.readXSF
+```
+
+### Writing
+```@docs
 Electrum.writeXSF
 ```
 

--- a/docs/src/filetypes.md
+++ b/docs/src/filetypes.md
@@ -99,3 +99,15 @@ Electrum.jl supports the reading and writing of LAMMPS atomic position data.
 
 !!! info Like VASP `POSCAR` files, LAMMPS data files do not contain explicit atomic information. If
 none is provided, dummy atoms corresponding to each atom type will be used.
+
+# TOML
+
+Electrum.jl can export `AbstractAtomPosition` and `Crystal` data to TOML files through the
+`writeTOML(file, data)` function. The internal `Electrum.toml_convert()` can be used to convert data
+to a dictionary that `TOML.print()` can support.
+
+This functionality works only if the TOML module is loaded (as a weak dependency through Requires).
+If it is not available, run the following command in the REPL:
+```
+julia> using TOML
+```

--- a/src/Electrum.jl
+++ b/src/Electrum.jl
@@ -6,6 +6,7 @@ using FFTW
 using Printf
 using ComputedFieldTypes
 using NormalForms
+using Requires
 
 const ELEMENTS = 
 ( 
@@ -166,5 +167,11 @@ export read_lammps_data, write_lammps_data
 include("show.jl")
 # Precompilation directives
 include("precompile.jl")
+
+function __init__()
+    @require TOML="fa267f1f-6049-4f14-aa54-33bafae1ed76" begin
+        include("software/toml.jl")
+    end
+end
 
 end # end of module

--- a/src/software/toml.jl
+++ b/src/software/toml.jl
@@ -33,9 +33,7 @@ function toml_convert(p::FractionalAtomPosition, b::AbstractBasis)
     return data
 end
 
-function toml_convert(l::AtomList)
-    return Dict{String,Any}(toml_convert.(l))
-end
+toml_convert(l::AtomList) = toml_convert.(l)
 
 function toml_convert(l::PeriodicAtomList)
     return Dict{String,Any}("basis" => toml_convert(basis(l)), "atoms" => toml_convert.(l))

--- a/src/software/toml.jl
+++ b/src/software/toml.jl
@@ -57,6 +57,6 @@ writeTOML(io::IO, x::Crystal; kwargs...) = TOML.print(io, toml_convert(x); kwarg
 Writes `x`, an Electrum data type, to a file. Currently, `x` may be either an `AbstractAtomList` or
 a `Crystal`.
 """
-function writeTOML(file, x; kwargs...) = open(io -> writeTOML(io, x; kwargs...), file)
+writeTOML(file, x; kwargs...) = open(io -> writeTOML(io, x; kwargs...), file; write=true)
 
 export writeTOML

--- a/src/software/toml.jl
+++ b/src/software/toml.jl
@@ -1,11 +1,11 @@
 """
-    Electrum.to_toml_data(x) -> Dict{String}
+    Electrum.toml_convert(x) -> Dict{String}
 
 Converts an Electrum data type to a dictionary, which `TOML.print()` supports for direct output.
 """
-function to_toml_data end
+function toml_convert end
 
-function to_toml_data(b::AbstractBasis)
+function toml_convert(b::AbstractBasis)
     return Dict{String,Any}(
         "realspace" => !(DataSpace(b) isa ByReciprocalSpace),
         "dimension" => size(b,1),
@@ -13,43 +13,43 @@ function to_toml_data(b::AbstractBasis)
     )
 end
 
-to_toml_data(a::NamedAtom) = Dict{String,Any}("name" => name(a), "number" => atomic_number(a))
+toml_convert(a::NamedAtom) = Dict{String,Any}("name" => name(a), "number" => atomic_number(a))
 
-function to_toml_data(p::CartesianAtomPosition)
-    data = to_toml_data(NamedAtom(p))
+function toml_convert(p::CartesianAtomPosition)
+    data = toml_convert(NamedAtom(p))
     data["cartesian"] = displacement(p)
     return data
 end
 
-function to_toml_data(p::FractionalAtomPosition)
-    data = to_toml_data(NamedAtom(p))
+function toml_convert(p::FractionalAtomPosition)
+    data = toml_convert(NamedAtom(p))
     data["fractional"] = displacement(p)
     return data
 end
 
-function to_toml_data(p::FractionalAtomPosition, b::AbstractBasis)
-    data = to_toml_data(p)
+function toml_convert(p::FractionalAtomPosition, b::AbstractBasis)
+    data = toml_convert(p)
     data["cartesian"] = RealBasis(b) * displacement(p)
     return data
 end
 
-function to_toml_data(l::AtomList)
-    return Dict{String,Any}(to_toml_data.(l))
+function toml_convert(l::AtomList)
+    return Dict{String,Any}(toml_convert.(l))
 end
 
-function to_toml_data(l::PeriodicAtomList)
-    return Dict{String,Any}("basis" => to_toml_data(basis(l)), "atoms" => to_toml_data.(l))
+function toml_convert(l::PeriodicAtomList)
+    return Dict{String,Any}("basis" => toml_convert(basis(l)), "atoms" => toml_convert.(l))
 end
 
-function to_toml_data(x::Crystal)
-    data = to_toml_data(x.atoms)
+function toml_convert(x::Crystal)
+    data = toml_convert(x.atoms)
     data["space_group"] = Dict{String,Any}("number" => x.sgno, "origin" => x.sgorig)
     data["transform"] = eachcol(x.transform)
     return data
 end
 
-writeTOML(io::IO, x::AbstractAtomList; kwargs...) = TOML.print(io, to_toml_data(x); kwargs...)
-writeTOML(io::IO, x::Crystal; kwargs...) = TOML.print(io, to_toml_data(x); kwargs...)
+writeTOML(io::IO, x::AbstractAtomList; kwargs...) = TOML.print(io, toml_convert(x); kwargs...)
+writeTOML(io::IO, x::Crystal; kwargs...) = TOML.print(io, toml_convert(x); kwargs...)
 
 """
     writeTOML(file, x; sorted=false, by=identity)

--- a/src/software/toml.jl
+++ b/src/software/toml.jl
@@ -1,36 +1,45 @@
-function TOML.print(io::IO, b::AbstractBasis)
-    println(io, "space = \"re", "cipro"^(DataSpace(b) isa ByReciprocalSpace), "al\"")
-    println(io, "vectors = [", )
-    for v in b
-        print(io, " "^4, "[")
-        join(io, v, ", ")
-        println(io, "],")
-    end
-    println(io, "]")
+function to_toml_data(b::AbstractBasis)
+    return Dict{String,Any}(
+        "realspace" => !(DataSpace(b) isa ByReciprocalSpace),
+        "dimension" => size(b,1),
+        "vectors" => b.vectors
+    )
 end
 
-function TOML.print(io::IO, p::PeriodicAtomList)
-    println(io, "[basis]")
-    TOML.print(io, basis(p))
-    for atom in p
-        println(io, "\n[[atoms]]")
-        println(io, "name = ", name(atom))
-        println(io, "number = ", atomic_number(atom))
-        println(io, "coordinate = ", displacement(atom))
-    end
+to_toml_data(a::NamedAtom) = Dict{String,Any}("name" => name(a), "number" => atomic_number(a))
+
+function to_toml_data(p::CartesianAtomPosition)
+    data = to_toml_data(NamedAtom(p))
+    data["cartesian"] = displacement(p)
+    return data
 end
 
-function TOML.print(io::IO, xtal::Crystal)
-    # Transform goes in the top-level table
-    println(io, "transform = [")
-    for v in eachcol(xtal.transform)
-        print(io, " "^4, "[")
-        join(io, v, ", ")
-        println(io, "],")
-    end
-    println(io, "]\n")
-    TOML.print(io, xtal.atoms)
-    println(io, "\n[space_group]")
-    println(io, "number = ", xtal.sgno)
-    println(io, "origin = ", xtal.sgorig)
+function to_toml_data(p::FractionalAtomPosition)
+    data = to_toml_data(NamedAtom(p))
+    data["fractional"] = displacement(p)
+    return data
 end
+
+function to_toml_data(p::FractionalAtomPosition, b::AbstractBasis)
+    data = to_toml_data(p)
+    data["cartesian"] = RealBasis(b) * displacement(p)
+    return data
+end
+
+function to_toml_data(l::AtomList)
+    return Dict{String,Any}(to_toml_data.(l))
+end
+
+function to_toml_data(l::PeriodicAtomList)
+    return Dict{String,Any}("basis" => to_toml_data(basis(l)), "atoms" => to_toml_data.(l))
+end
+
+function to_toml_data(x::Crystal)
+    data = to_toml_data(x.atoms)
+    data["space_group"] = Dict{String,Any}("number" => x.sgno, "origin" => x.sgorig)
+    data["transform"] = eachcol(x.transform)
+    return data
+end
+
+TOML.print(io::IO, x::AbstractAtomList; kwargs...) = TOML.print(io, to_toml_data(x); kwargs...)
+TOML.print(io::IO, x::Crystal; kwargs...) = TOML.print(io, to_toml_data(x); kwargs...)

--- a/src/software/toml.jl
+++ b/src/software/toml.jl
@@ -1,3 +1,10 @@
+"""
+    Electrum.to_toml_data(x) -> Dict{String}
+
+Converts an Electrum data type to a dictionary, which `TOML.print()` supports for direct output.
+"""
+function to_toml_data end
+
 function to_toml_data(b::AbstractBasis)
     return Dict{String,Any}(
         "realspace" => !(DataSpace(b) isa ByReciprocalSpace),

--- a/src/software/toml.jl
+++ b/src/software/toml.jl
@@ -41,10 +41,10 @@ function toml_convert(l::PeriodicAtomList)
     return Dict{String,Any}("basis" => toml_convert(basis(l)), "atoms" => toml_convert.(l))
 end
 
-function toml_convert(x::Crystal)
+function toml_convert(x::Crystal{D}) where D
     data = toml_convert(x.atoms)
     data["space_group"] = Dict{String,Any}("number" => x.sgno, "origin" => x.sgorig)
-    data["transform"] = eachcol(x.transform)
+    data["transform"] = SVector{D}(eachcol(x.transform))
     return data
 end
 

--- a/src/software/toml.jl
+++ b/src/software/toml.jl
@@ -48,5 +48,15 @@ function to_toml_data(x::Crystal)
     return data
 end
 
-TOML.print(io::IO, x::AbstractAtomList; kwargs...) = TOML.print(io, to_toml_data(x); kwargs...)
-TOML.print(io::IO, x::Crystal; kwargs...) = TOML.print(io, to_toml_data(x); kwargs...)
+writeTOML(io::IO, x::AbstractAtomList; kwargs...) = TOML.print(io, to_toml_data(x); kwargs...)
+writeTOML(io::IO, x::Crystal; kwargs...) = TOML.print(io, to_toml_data(x); kwargs...)
+
+"""
+    writeTOML(file, x; sorted=false, by=identity)
+
+Writes `x`, an Electrum data type, to a file. Currently, `x` may be either an `AbstractAtomList` or
+a `Crystal`.
+"""
+function writeTOML(file, x; kwargs...) = open(io -> writeTOML(io, x; kwargs...), file)
+
+export writeTOML

--- a/src/software/toml.jl
+++ b/src/software/toml.jl
@@ -56,6 +56,9 @@ writeTOML(io::IO, x::Crystal; kwargs...) = TOML.print(io, toml_convert(x); kwarg
 
 Writes `x`, an Electrum data type, to a file. Currently, `x` may be either an `AbstractAtomList` or
 a `Crystal`.
+
+The `sorted` and `by` keywords are passed through from `TOML.print` and allow for sorting of the
+keys in the file output.
 """
 writeTOML(file, x; kwargs...) = open(io -> writeTOML(io, x; kwargs...), file; write=true)
 

--- a/src/software/toml.jl
+++ b/src/software/toml.jl
@@ -1,0 +1,36 @@
+function TOML.print(io::IO, b::AbstractBasis)
+    println(io, "space = \"re", "cipro"^(DataSpace(b) isa ByReciprocalSpace), "al\"")
+    println(io, "vectors = [", )
+    for v in b
+        print(io, " "^4, "[")
+        join(io, v, ", ")
+        println(io, "],")
+    end
+    println(io, "]")
+end
+
+function TOML.print(io::IO, p::PeriodicAtomList)
+    println(io, "[basis]")
+    TOML.print(io, basis(p))
+    for atom in p
+        println(io, "\n[[atoms]]")
+        println(io, "name = ", name(atom))
+        println(io, "number = ", atomic_number(atom))
+        println(io, "coordinate = ", displacement(atom))
+    end
+end
+
+function TOML.print(io::IO, xtal::Crystal)
+    # Transform goes in the top-level table
+    println(io, "transform = [")
+    for v in eachcol(xtal.transform)
+        print(io, " "^4, "[")
+        join(io, v, ", ")
+        println(io, "],")
+    end
+    println(io, "]\n")
+    TOML.print(io, xtal.atoms)
+    println(io, "\n[space_group]")
+    println(io, "number = ", xtal.sgno)
+    println(io, "origin = ", xtal.sgorig)
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,4 +2,5 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/filetypes.jl
+++ b/test/filetypes.jl
@@ -60,9 +60,7 @@ end
     using TOML
     xtal = v80_den.xtal
     toml_path = joinpath(tmpdir, "test.toml")
-    open(toml_path, write=true) do io
-        TOML.print(io, v80_den.xtal)
-    end
+    writeTOML(toml_path, xtal)
     toml = TOML.parsefile(joinpath(tmpdir, "test.toml"))
     @test toml["transform"] == eachcol(xtal.transform)
     @test toml["basis"]["vectors"] == eachcol(basis(xtal))

--- a/test/filetypes.jl
+++ b/test/filetypes.jl
@@ -55,3 +55,19 @@ end
     @test all(isapprox.(displacement.(lammps.atoms), displacement.(poscar.atoms), atol=1e-6))
     @test isapprox(basis(lammps), basis(poscar), atol=1e-6 * Electrum.ANG2BOHR)
 end
+
+@testset "TOML" begin
+    using TOML
+    xtal = v80_den.xtal
+    toml_path = joinpath(tmpdir, "test.toml")
+    open(toml_path, write=true) do io
+        TOML.print(io, v80_den.xtal)
+    end
+    toml = TOML.parsefile(joinpath(tmpdir, "test.toml"))
+    @test toml["transform"] == eachcol(xtal.transform)
+    @test toml["basis"]["vectors"] == eachcol(basis(xtal))
+    @test toml["basis"]["dimension"] == 3
+    @test toml["basis"]["realspace"]
+    @test length(toml["atoms"]) == 2
+    @test toml["atoms"][1]["name"] == "Sc"
+end

--- a/test/filetypes.jl
+++ b/test/filetypes.jl
@@ -62,8 +62,8 @@ end
     toml_path = joinpath(tmpdir, "test.toml")
     writeTOML(toml_path, xtal)
     toml = TOML.parsefile(joinpath(tmpdir, "test.toml"))
-    @test toml["transform"] == eachcol(xtal.transform)
-    @test toml["basis"]["vectors"] == eachcol(basis(xtal))
+    @test toml["transform"] == collect(eachcol(xtal.transform))
+    @test toml["basis"]["vectors"] == collect(eachcol(basis(xtal)))
     @test toml["basis"]["dimension"] == 3
     @test toml["basis"]["realspace"]
     @test length(toml["atoms"]) == 2


### PR DESCRIPTION
This should allow direct export of data to TOML files. When the TOML module is loaded, the `writeTOML()` function is exported, and `Electrum.toml_convert()` allows for Electrum data types to be converted to a type usable by `TOML.print()`.