### PR TITLE
Eliminate bounds checking for `DataGrid`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+  - Cartesian indexing for `DataGrid` skips out on unnecessary bounds checking (due to periodicity).
+
 ## [0.1.6]: 2023-07-03
 
 ### Added

--- a/src/data/grids.jl
+++ b/src/data/grids.jl
@@ -140,8 +140,8 @@ Base.size(g::DataGrid) = size(g.data)
 Base.axes(g::DataGrid{D}) where D = NTuple{D}(range(0, stop = x - 1) for x in size(g))
 
 # Linear indexing should be defined automatically
-Base.getindex(g::DataGrid, i...) = getindex(g.data, reinterpret_index(g, i)...)
-Base.setindex!(g::DataGrid, x, i...) = setindex!(g.data, x, reinterpret_index(g, i)...)
+Base.getindex(g::DataGrid, i...) = @inbounds getindex(g.data, reinterpret_index(g, i)...)
+Base.setindex!(g::DataGrid, x, i...) = @inbounds setindex!(g.data, x, reinterpret_index(g, i)...)
 
 Base.getindex(g::DataGrid, i::CartesianIndex) = getindex(g, i.I...)
 Base.setindex!(g::DataGrid, x, i::CartesianIndex) = setindex!(g, x, i.I...)

--- a/test/datagrids.jl
+++ b/test/datagrids.jl
@@ -28,6 +28,13 @@
     @test basis(z) == ReciprocalBasis(g)
     @test shift(z) isa KPoint{3}
     @test weight(shift(z)) == 1
+    # Indexing
+    @test g[1,2,3] === g[CartesianIndex(1,2,3)]
+    @test g[end] === g[3,3,3]
+    @test g[end] === g[63]
+    @test eachindex(IndexLinear(), z) == 0:(prod(size(z)) - 1)
+    @test all(iszero, firstindex(z, n) for n in 1:3)
+    @test [lastindex(z, n) for n in 1:3] == collect(size(z) .- 1)
 end
 
 @testset "Fourier transforms" begin


### PR DESCRIPTION
Because the Cartesian indices are periodic, inbound array access is already guaranteed. This should speed things up a bit.

This change has not altered the behavior of linear indexing, which does involve bounds checking by default (and can be overridden with `@inbounds` if desired).