### PR TITLE
Added back `AbstractBasis` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+  - `Electrum.BySpace{D}` as a supertype for `ByRealSpace{D}` and `ByReciprocalSpace{D}`
+  - `AbstractBasis{D,T}` as a type alias for `Electrum.LatticeBasis{<:Electrum.BySpace,D,T}`
+
 ### Changed
   - Cartesian indexing for `DataGrid` skips out on unnecessary bounds checking (due to periodicity).
 

--- a/docs/src/api/lattices.md
+++ b/docs/src/api/lattices.md
@@ -4,6 +4,7 @@
 ```@docs
 Electrum.RealBasis
 Electrum.ReciprocalBasis
+Electrum.AbstractBasis
 ```
 
 ## Methods

--- a/src/Electrum.jl
+++ b/src/Electrum.jl
@@ -109,7 +109,7 @@ export FFTBins, FFTLength
 include("traits.jl")
 # Methods and structs for working with crystal lattices
 include("lattices.jl")
-export RealBasis, ReciprocalBasis
+export RealBasis, ReciprocalBasis, AbstractBasis
 export basis, lengths, volume, angles_cos, angles_rad, angles_deg, gram, isdiag, qr, triangularize, 
     maxHKLindex
 # Methods and structs for working with atomic positions

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -67,11 +67,11 @@ For further information, see `Electrum.LatticeBasis`.
 const ReciprocalBasis = LatticeBasis{ByReciprocalSpace}
 
 """
-    AbstractBasis{D,T} (alias for Union{RealBasis{D,T},ReciprocalBasis{D,T}})
+    AbstractBasis{D,T} (alias for LatticeBasis{<:Electrum.BySpace,D,T})
 
-Union type for `RealBasis{D,T}` and `ReciprocalBasis{D,T}`.
+Supertype that can be used to refer to either a `RealBasis{D,T}` or a `ReciprocalBasis{D,T}`.
 """
-const AbstractBasis{D,T} = Union{RealBasis{D,T},ReciprocalBasis{D,T}}
+const AbstractBasis = LatticeBasis{<:BySpace}
 
 LatticeBasis{S,D,T}(t::Tuple) where {S,D,T} = LatticeBasis{S,D,T}(SMatrix{D,D}(t))
 LatticeBasis{S,D,T}(M::AbstractMatrix) where {S,D,T} = LatticeBasis{S,D,T}(SMatrix{D,D}(M))

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -66,7 +66,12 @@ For further information, see `Electrum.LatticeBasis`.
 """
 const ReciprocalBasis = LatticeBasis{ByReciprocalSpace}
 
-const AbstractBasis = LatticeBasis{S} where S<:Union{ByRealSpace,ByReciprocalSpace}
+"""
+    AbstractBasis{D,T} (alias for Union{RealBasis{D,T},ReciprocalBasis{D,T}})
+
+Union type for `RealBasis{D,T}` and `ReciprocalBasis{D,T}`.
+"""
+const AbstractBasis{D,T} = Union{RealBasis{D,T},ReciprocalBasis{D,T}}
 
 LatticeBasis{S,D,T}(t::Tuple) where {S,D,T} = LatticeBasis{S,D,T}(SMatrix{D,D}(t))
 LatticeBasis{S,D,T}(M::AbstractMatrix) where {S,D,T} = LatticeBasis{S,D,T}(SMatrix{D,D}(M))

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -18,11 +18,27 @@ abstract type DataSpace{D} <: CrystalDataTrait
 end
 
 """
+    ByAtom{D}
+
+Trait for data associated with atomic positions in a crystal.
+"""
+struct ByAtom{D} <: DataSpace{D}
+end
+
+"""
+    BySpace{D}
+
+Supertype for the `ByRealSpace{D}` and `ByReciprocalSpace{D}` traits.
+"""
+abstract type BySpace{D}
+end
+
+"""
     ByRealSpace{D}
 
 Trait for real space data in `D` dimensions.
 """
-struct ByRealSpace{D} <: DataSpace{D}
+struct ByRealSpace{D} <: BySpace{D}
 end
 
 """
@@ -30,13 +46,5 @@ end
 
 Trait for reciprocal space data in `D` dimensions.
 """
-struct ByReciprocalSpace{D} <: DataSpace{D}
-end
-
-"""
-    ByAtom{D}
-
-Trait for data associated with atomic positions in a crystal.
-"""
-struct ByAtom{D} <: DataSpace{D}
+struct ByReciprocalSpace{D} <: BySpace{D}
 end


### PR DESCRIPTION
Back when the type system wasn't as well developed, I had an `AbstractBasis{D}` type that encompassed both `RealBasis{D}` and `ReciprocalBasis{D}`. Now that `Electrum.LatticeBasis{S,D,T}` is the foundation for the types, I've added back this `AbstractBasis` type as an alias for convenience.

To faciliate this, I've grouped `Electurm.ByRealSpace{D}` and `Electrum.ByReciprocalSpace{D}` into a supertype, `Electrum.BySpace{D}`.