### PR TITLE
Broadened element type specification for `KPoint`

### DIFF
--- a/src/data/bands.jl
+++ b/src/data/bands.jl
@@ -40,15 +40,15 @@ nband(b::BandAtKPoint) = length(b.e)
     BandStructure{D}
 
 Stores information about an electronic band structure, including the list of k-points used to
-generate the data (as am `AbstractVector{KPoint{D}}`)and the band information at every k-point (as a
-`Vector{BandAtKPoint}`).
+generate the data (as am `AbstractVector{KPoint{D,Float64}}`) and the band information at every
+k-point (as a `Vector{BandAtKPoint}`).
 """
 struct BandStructure{D}
     # k-points for which band data is defined
-    kpts::Vector{KPoint{D}}
+    kpts::Vector{KPoint{D,Float64}}
     # Set of energy and occupancy data
     bands::Vector{BandAtKPoint}
-    function BandStructure(kpts::AbstractVector{KPoint{D}}, bands::Vector{BandAtKPoint}) where D
+    function BandStructure(kpts::AbstractVector{<:KPoint{D}}, bands::Vector{BandAtKPoint}) where D
         @assert nkpt(kpts) == length(bands) "Incorrect number of k-points or band datasets."
         @assert _allsame(length(bands)) "Number of bands is inconsistent."
         return new{D}(kpts, bands)
@@ -62,7 +62,7 @@ Generates a new band structure from k-point information and a vector containing 
 each k-point.
 """
 function BandStructure(
-    kpts::AbstractVector{KPoint{D}},
+    kpts::AbstractVector{<:KPoint{D}},
     bands::AbstractVector{<:BandAtKPoint}
 ) where D
     return BandStructure(kpts, bands)

--- a/src/data/grids.jl
+++ b/src/data/grids.jl
@@ -26,7 +26,7 @@ For convenience, the aliases `RealDataGrid` and `ReciprocalDataGrid` are provide
 below:
 
     const RealDataGrid{D} = DataGrid{RealBasis{D,Float64},SVector{D,Float64},D}
-    const ReciprocalDataGrid{D} = DataGrid{ReciprocalBasis{D,Float64},KPoint{D},D}
+    const ReciprocalDataGrid{D} = DataGrid{ReciprocalBasis{D,Float64},KPoint{D,Float64},D}
 
 Note that `ReciprocalDataGrid` uses a `KPoint{D}` to represent the shift, as opposed to an 
 `SVector{D}`. This allows for the concurrent storage of a weight along with the shift, which may be
@@ -50,7 +50,7 @@ Base.has_offset_axes(g::DataGrid) = true
 Base.show(io::IO, g::DataGrid) = print(io, typeof(g), (g.data, g.basis, g.shift))
 
 const RealDataGrid{D,T} = DataGrid{D,RealBasis{D,Float64},SVector{D,Float64},T}
-const ReciprocalDataGrid{D,T} = DataGrid{D,ReciprocalBasis{D,Float64},KPoint{D},T}
+const ReciprocalDataGrid{D,T} = DataGrid{D,ReciprocalBasis{D,Float64},KPoint{D,Float64},T}
 
 #---Constructors-----------------------------------------------------------------------------------#
 """
@@ -59,8 +59,8 @@ const ReciprocalDataGrid{D,T} = DataGrid{D,ReciprocalBasis{D,Float64},KPoint{D},
 Generates a default zero shift vector whose type depends on the type of the basis vector.
 
 This function is needed because `RealDataGrid` uses `SVector{D,Float64}` as its shift vector, and
-`ReciprocalDataGrid` uses `KPoint{D}`. Depending on the basis vector type used in the constructor,
-the shift vector type must be automatically determined if not supplied.
+`ReciprocalDataGrid` uses `KPoint{D,Float64}`. Depending on the basis vector type used in the
+constructor, the shift vector type must be automatically determined if not supplied.
 """
 zero_shift(::Type{<:RealBasis{D}}) where D = zero(SVector{D,Float64})
 zero_shift(::Type{<:ReciprocalBasis{D}}) where D = zero(KPoint{D})

--- a/src/data/kpoints.jl
+++ b/src/data/kpoints.jl
@@ -7,7 +7,7 @@ k-points, stored as an integer.
 struct KPoint{D,T} <: DenseVector{T}
     point::SVector{D,T}
     weight::Int
-    KPoint{D,T}(pt::AbstractVector{<:Real}, wt::Integer = 1) where {D,T} = new(pt .- round(pt), wt)
+    KPoint{D,T}(pt::AbstractVector{<:Real}, wt::Integer = 1) where {D,T} = new(pt .- round.(pt), wt)
 end
 
 KPoint{D}(pt::AbstractVector{T}, wt::Integer = 1) where {D,T} = KPoint{D,T}(pt, wt)

--- a/src/data/wavefunctions.jl
+++ b/src/data/wavefunctions.jl
@@ -177,7 +177,7 @@ function PlanewaveWavefunction{D,T}(
     return PlanewaveWavefunction(
         basis,
         zeros(SVector{D,Float64}, nspin),
-        KPointMesh(zeros(KPoint{D}, nkpt)),
+        KPointMesh(zeros(KPoint{D,Float64}, nkpt)),
         zeros(Float64, nband, nkpt, nspin),
         zeros(Float64, nband, nkpt, nspin),
         grange,

--- a/src/data/wavefunctions.jl
+++ b/src/data/wavefunctions.jl
@@ -130,7 +130,7 @@ but they are not resizable, and the backing array should not be resized.
 struct PlanewaveWavefunction{D,T} <: AbstractArray{T,D}
     basis::ReciprocalBasis{D,Float64}
     spins::Vector{SVector{D,Float64}}
-    kpoints::KPointMesh{D}
+    kpoints::KPointMesh{D,Float64}
     energies::Array{Float64,3}
     occupancies::Array{Float64,3}
     grange::NTuple{D,UnitRange{Int}}


### PR DESCRIPTION
This should allow the use of different data types for k-point specification (e.g. `Float32`, `Rational{Int}`) rather than hard-coded as `Float64`.