### PR TITLE
Remove automatic k-point rounding

### DIFF
--- a/src/data/kpoints.jl
+++ b/src/data/kpoints.jl
@@ -39,8 +39,15 @@ Returns the weight associated with a k-point.
 """
 weight(k::KPoint) = k.weight
 
-#---Generated lists of k-points--------------------------------------------------------------------#
+# TODO: can we implement a remainder that excludes -0.5?
+"""
+    truncate(k::KPoint) -> KPoint
 
+Moves a k-point so that its values lie within the range [-1/2, 1/2]. The weight is preserved.
+"""
+Base.truncate(k::KPoint) = KPoint(rem.(k.point, 1, RoundNearest), k.weight)
+
+#---Generated lists of k-points--------------------------------------------------------------------#
 """
     KPointMesh{D} <: AbstractVector{KPoint{D}}
 

--- a/src/data/kpoints.jl
+++ b/src/data/kpoints.jl
@@ -1,5 +1,5 @@
 """
-    KPoint{D} <: DenseVector{D,Float64}
+    KPoint{D} <: DenseVector{Float64}
 
 Stores a k-point with an associated weight that corresponds to the number of symmetry-equivalent
 k-points, stored as an integer.

--- a/src/data/kpoints.jl
+++ b/src/data/kpoints.jl
@@ -7,7 +7,7 @@ k-points, stored as an integer.
 struct KPoint{D} <: DenseVector{Float64}
     point::SVector{D,Float64}
     weight::Int
-    KPoint(pt::StaticVector{D,<:Real}, wt::Integer = 1) where D = new{D}(pt .- round.(pt), wt)
+    KPoint(pt::StaticVector{D,<:Real}, wt::Integer = 1) where D = new{D}(pt, wt)
 end
 
 KPoint(x::Real...; weight::Integer = 1) = KPoint(SVector(x), weight)

--- a/test/kpoints.jl
+++ b/test/kpoints.jl
@@ -1,7 +1,13 @@
 @testset "k-points" begin
     @test KPoint(0, 0, 0, weight = 1) != KPoint(0, 0, 0, weight = 2)
     @test hash(KPoint(0, 0, 0, weight = 1)) != hash(KPoint(0, 0, 0, weight = 2))
-    @test KPoint(1, 2, 3) == KPoint(0, 0, 0)
+    # Truncation
+    # TODO: see note for trunc() in Electrum.jl/src/kpoints.jl
+    @test truncate(KPoint(1, 2, 3)) == KPoint(0, 0, 0)
+    @test truncate(KPoint(0.5, -0.5, 1.5)) == KPoint(0.5, -0.5, -0.5)
+    @test truncate(KPoint(0.5, -0.5 + eps(Float64), 1.5)) == KPoint(0.5, -0.5 + eps(Float64), -0.5)
+    @test truncate(KPoint(0.5, -0.5 - eps(Float64), 1.5)) == KPoint(0.5,  0.5 - eps(Float64), -0.5)
+    # Length measurement
     @test length(KPoint(1, 2, 3, 4, 5)) == 5
     @test length(KPoint{2}) == 2
 end


### PR DESCRIPTION
This can cause serious problems when reading wavefunction files where the k-point coordinate is slightly above 0.5 or below -0.5.