### PR TITLE
`NamedAtom` now uses the `InlineString15` type for its field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+  - New dependency on [InlineStrings.jl](https://github.com/JuliaStrings/InlineStrings.jl)
+
+### Changed
+  - `NamedAtom` now uses the `InlineString15` type instead of using an `NTuple{8,Char}`
+
 ### Fixed
   - Admonition boxes in documentation now render correctly
 
@@ -110,6 +116,7 @@ provided `oneunit(T)` is defined.
 Initial release of Electrum.jl
 
 [Unreleased]: https://github.com/brainandforce/Electrum.jl
+[0.1.10]: https://github.com/brainandforce/Electrum.jl/releases/tag/v0.1.10
 [0.1.9]: https://github.com/brainandforce/Electrum.jl/releases/tag/v0.1.9
 [0.1.8]: https://github.com/brainandforce/Electrum.jl/releases/tag/v0.1.8
 [0.1.7]: https://github.com/brainandforce/Electrum.jl/releases/tag/v0.1.7

--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 ComputedFieldTypes = "1"
 FFTW = "1"
+InlineStrings = "1"
 NormalForms = "0.1"
 StaticArrays = "1"
 Requires = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.11-dev"
 [deps]
 ComputedFieldTypes = "459fdd68-db75-56b8-8c15-d717a790f88e"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+InlineStrings = "842dd82b-1e85-43dc-bf29-5d0ee9dffc48"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NormalForms = "109d20d8-9763-411c-9b60-7eb2a068657f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/src/Electrum.jl
+++ b/src/Electrum.jl
@@ -4,9 +4,12 @@ using LinearAlgebra
 using StaticArrays
 using FFTW
 using Printf
+using InlineStrings
 using ComputedFieldTypes
 using NormalForms
 using Requires
+
+import InlineStrings.InlineString15
 
 const ELEMENTS = 
 ( 

--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -1,29 +1,13 @@
 """
     NamedAtom
 
-Stores information about an atom, which includes a name which may be up to 8 codepoints long, and
+Stores information about an atom, which includes a name which may be up to 15 codepoints long, and
 the atomic number.
-
-Internally, the name is stored as a `NTuple{8,Char}` in the `name` field to guarantee that the type
-is pure bits. However, the `name` property returns a `String`.
 """
 struct NamedAtom
-    name::NTuple{8,Char}
+    name::InlineString15
     num::Int
-    function NamedAtom(name::AbstractString, num::Integer)
-        codepoints = ntuple(Val{8}()) do i
-            i <= length(name) ? name[i] : '\0'
-        end
-        return new(codepoints, num)
-    end
-end
-
-function Base.getproperty(atom::NamedAtom, p::Symbol)
-    if p == :name
-        l = findfirst(isequal('\0'), getfield(atom, p))
-        return string(getfield(atom, p)[1:l-1]...)
-    end
-    return getfield(atom, p)
+    NamedAtom(name::AbstractString, num::Integer) = new(name, num)
 end
 
 """

--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -110,7 +110,7 @@ isdummy(a::NamedAtom) = iszero(a.num)
 
 Base.convert(T::Type{<:AbstractString}, a::NamedAtom) = convert(T, name(a))
 Base.convert(T::Type{<:Number}, a::NamedAtom) = convert(T, atomic_number(a))
-Base.convert(::Type{NamedAtom}, x) = NamedAtom(x)
+Base.convert(::Type{NamedAtom}, x::Union{AbstractString,Number}) = NamedAtom(x)
 
 """
     Electrum.reset_name(a::NamedAtom)

--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -53,7 +53,8 @@ end
     name(a::NamedAtom) -> String
 
 Returns the name associated with a `NamedAtom`. For atoms constructed with only an atomic number,
-the name will be the atomic symbol.
+the name will be the atomic symbol. This function returns a `Base.String` for compatibility, not the
+`InlineStrings.InlineString15` from the backing field.
 
 # Examples
 ```
@@ -64,7 +65,7 @@ julia> name(a)
 "Cl1"
 ```
 """
-name(a::NamedAtom) = a.name
+name(a::NamedAtom) = convert(String, a.name)
 
 """
     atomic_number(a::NamedAtom)

--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -108,6 +108,10 @@ true
 """
 isdummy(a::NamedAtom) = iszero(a.num)
 
+Base.convert(T::Type{<:AbstractString}, a::NamedAtom) = convert(T, name(a))
+Base.convert(T::Type{<:Number}, a::NamedAtom) = convert(T, atomic_number(a))
+Base.convert(::Type{NamedAtom}, x) = NamedAtom(x)
+
 """
     Electrum.reset_name(a::NamedAtom)
 

--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -109,8 +109,8 @@ true
 """
 isdummy(a::NamedAtom) = iszero(a.num)
 
-Base.convert(T::Type{<:AbstractString}, a::NamedAtom) = convert(T, name(a))
-Base.convert(T::Type{<:Number}, a::NamedAtom) = convert(T, atomic_number(a))
+Base.convert(T::Type{<:AbstractString}, a::NamedAtom) = convert(T, a.name)
+Base.convert(T::Type{<:Number}, a::NamedAtom) = convert(T, a.num)
 Base.convert(::Type{NamedAtom}, x::Union{AbstractString,Number}) = NamedAtom(x)
 
 """

--- a/test/atoms.jl
+++ b/test/atoms.jl
@@ -6,4 +6,9 @@
     @test isdummy(a) === false
     @test NamedAtom(17) === NamedAtom("Cl", 17)
     @test isdummy(NamedAtom("test")) === true
+    @test convert(String, a) == "Cl1"
+    @test convert(Int, a) === 17
+    @test convert(NamedAtom, 69) == NamedAtom("Tm")
+    @test convert(NamedAtom, "Tm") == NamedAtom(69)
+    @test convert(NamedAtom, "Tm420") == NamedAtom("Tm420", 69)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,8 +3,21 @@ using Test, Aqua, Electrum
 
 tmpdir = mktempdir()
 
+excluded_methods = Function[Base.unsafe_convert]
+# Base.getindex ambiguity was resolved in 1.9:
+# https://github.com/JuliaLang/julia/pull/41807
+# TODO: can we still try to test other methods for Base.getindex? It's pretty important...
+if VERSION < v"1.9"
+    push!(excluded_methods, Base.getindex)
+end
+# Base.Sort.defalg ambiguity should be removed in 1.10:
+# https://github.com/JuliaLang/julia/pull/47383
+if VERSION < v"1.10"
+    push!(excluded_methods, Base.Sort.defalg)
+end
+
 Aqua.test_all(Electrum;
-    ambiguities = (exclude = [Base.Sort.defalg, Base.unsafe_convert],),
+    ambiguities = (exclude = excluded_methods,),
     project_toml_formatting = false
 )
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,10 @@ using Test, Aqua, Electrum
 
 tmpdir = mktempdir()
 
-Aqua.test_all(Electrum; project_toml_formatting=false)
+Aqua.test_all(Electrum;
+    ambiguities = (exclude = [Base.Sort.defalg, Base.unsafe_convert],),
+    project_toml_formatting = false
+)
 
 xsf = readXSF3D("files/test.xsf")
 header_den = Electrum.read_abinit_header("files/Sc_eq_o_DEN")


### PR DESCRIPTION
The InlineStrings.jl package provides string types that are pure bits, which should avoid all of the weirdness with `NTuple{8,Char}` used for the `NamedAtom` type internally.

The only problem that arises with adding InlineStrings.jl is the method ambiguities for `Base.Sort.defalg` and `Base.unsafe_convert`, which Aqua throws an error for, so testing of these functions for ambiguities is manually excluded. The latter may be fixed in a pull request for InlineStrings.jl, but the `Base.Sort.defalg` ambiguity might actually be an issue with Julia Base.