### PR TITLE
Add `min_energy(::PlanewaveWavefunction)` and `max_energy(::PlanewaveWavefunction)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+  - New `min_energy` and `max_energy` functions for `PlanewaveWavefunction`.
+
 ## [0.1.11]: 2023-10-22
 
 ### Added

--- a/docs/src/api/data.md
+++ b/docs/src/api/data.md
@@ -41,6 +41,8 @@ Electrum.PlanewaveIndex
 Electrum.nspin
 Electrum.nband(::PlanewaveWavefunction)
 Electrum.fermi(::PlanewaveWavefunction)
+Electrum.min_energy(::PlanewaveWavefunction)
+Electrum.max_energy(::PlanewaveWavefunction)
 ```
 
 ## Band structures

--- a/src/Electrum.jl
+++ b/src/Electrum.jl
@@ -137,7 +137,7 @@ export shift, fft, ifft, fftfreq, voxelsize, integrate, partial_derivative, cell
 # Planewave wavefunctions
 include("data/wavefunctions.jl")
 export PlanewaveIndex, PlanewaveWavefunction
-export fermi
+export fermi, min_energy, max_energy
 # Band structures
 include("data/bands.jl")
 export BandAtKPoint, BandStructure

--- a/src/data/wavefunctions.jl
+++ b/src/data/wavefunctions.jl
@@ -300,3 +300,20 @@ function fermi(wf::PlanewaveWavefunction)
     approx = (maxocc/2 - eo_sorted[ind][2]) / (eo_sorted[ind+1][2] - eo_sorted[ind][2])
     return eo_sorted[ind][1] * approx + eo_sorted[ind+1][1] * (1 - approx)
 end
+
+"""
+    min_energy(wf::PlanewaveWavefunction) -> Float64
+
+Returns the minimum energy value (in Hartrees) in the energy entries for a `PlanewaveWavefunction`.
+"""
+min_energy(wf::PlanewaveWavefunction) = minimum(wf.energies)
+
+"""
+    max_energy(wf::PlanewaveWavefunction) -> Float64
+
+Returns the maximum energy value (in Hartrees) in the energy entries for a `PlanewaveWavefunction`.
+
+Note that this maximum energy will likely correspond to an unoccupied state, and should not be taken
+to be the Fermi energy. For this value, see `fermi(wf)`.
+"""
+max_energy(wf::PlanewaveWavefunction) = maximum(wf.energies)

--- a/test/wavefunctions.jl
+++ b/test/wavefunctions.jl
@@ -17,4 +17,7 @@
     @test wavecar[i] == wavecar[CartesianIndex(i)]
     @test wavecar[1, 2, 3] isa ReciprocalDataGrid{3}
     @test vec(wavecar[1, 2, 3].data) == vec(wavecar.data[:, 3, 2, 1])
+    @test min_energy(wavecar) == minimum(wavecar.energies)
+    @test max_energy(wavecar) == maximum(wavecar.energies)
+    @test min_energy(wavecar) < fermi(wavecar) < max_energy(wavecar)
 end


### PR DESCRIPTION
Along with `fermi(::PlanewaveWavefunction)` this should help package users get this critical data without having to dive into the internals of `PlanewaveWavefunction` objects.