### PR TITLE
New `Electrum.dimension` internal function and upgrades to `Electrum.DataSpace` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
   - New `min_energy` and `max_energy` functions for `PlanewaveWavefunction`.
+  - New internal `Electrum.dimension` function, which returns the type parameter of
+`Electrum.DataSpace{D}` (usually a number). For objects and types with a `Electrum.DataSpace` trait,
+this returns the associated dimension object.
+  - Fallback defintion for `Electrum.DataSpace(::Type{T}) where T`
+
+### Fixed
+  - `BySpace{D}` did not subtype `DataSpace{D}`.
 
 ## [0.1.11]: 2023-10-22
 

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -128,8 +128,10 @@ By default, `DataSpace(x)` will infer the appropriate trait from the lattice bas
 included in `x`. The fallback definition is:
 
     DataSpace(x) = DataSpace(typeof(basis(x))) # basis(x) falls back to x.basis
+    DataSpace(::Type{T}) where T = DataSpace(fieldtype(T, :basis))
 """
 DataSpace(x) = DataSpace(typeof(basis(x)))
+DataSpace(::Type{T}) where T = DataSpace(fieldtype(T, :basis))
 
 #---Type promotion---------------------------------------------------------------------------------#
 

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -118,11 +118,11 @@ DataSpace(::Type{<:LatticeBasis{S,D}}) where {S,D} = S{D}()
 DataSpace(b::LatticeBasis) = DataSpace(typeof(b))
 
 """
-    Electrum.DataSpace(x) -> CrystalDataTrait
+    Electrum.DataSpace(x) -> DataSpace
 
 Returns a trait that determines whether a data set associated with a crystal is defined in real
-space (`RealSpaceData{D}()`), reciprocal space (`ReciprocalSpaceData{D}()`), or by atomic positions
-(`AtomPositionData{D}`), where `D` is the number of dimensions.
+space (`ByRealSpace{D}()`), reciprocal space (`ByReciprocalSpace{D}()`), or by atomic positions
+(`ByAtom{D}`), where `D` is the number of dimensions.
 
 By default, `DataSpace(x)` will infer the appropriate trait from the lattice basis vectors
 included in `x`. The fallback definition is:

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -1,5 +1,4 @@
 #---Traits----------------------------------------------------------------------------------------#
-
 """
     CrystalDataTrait
 
@@ -48,3 +47,13 @@ Trait for reciprocal space data in `D` dimensions.
 """
 struct ByReciprocalSpace{D} <: BySpace{D}
 end
+
+"""
+    Electrum.dimension(::DataSpace{D}) = D
+    Electrum.dimension(::Type{<:DataSpace{D}}) = D
+
+Returns the number of dimensions (or other object representing the dimensionality) associated with a
+`DataSpace` trait.
+"""
+dimension(::DataSpace{D}) where D = D
+dimension(::Type{<:DataSpace{D}}) where D = D

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -57,3 +57,10 @@ Returns the number of dimensions (or other object representing the dimensionalit
 """
 dimension(::DataSpace{D}) where D = D
 dimension(::Type{<:DataSpace{D}}) where D = D
+
+"""
+    Electrum.dimension(x)
+
+Infers the number of dimensions `Electrum.DataSpace(x)` from the result of `DataSpace(x)`.
+"""
+dimension(x) = dimension(DataSpace(x))

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -29,7 +29,7 @@ end
 
 Supertype for the `ByRealSpace{D}` and `ByReciprocalSpace{D}` traits.
 """
-abstract type BySpace{D}
+abstract type BySpace{D} <: DataSpace{D}
 end
 
 """

--- a/test/internals.jl
+++ b/test/internals.jl
@@ -28,10 +28,10 @@
     @test Electrum.SUnitVector{3}(1)[:] === SVector{3,Bool}(1, 0, 0)
     @test Electrum.SUnitVector{3}(1)[1:2] == [1, 0]
     @test_throws MethodError Electrum.SUnitVector{3,Char}(1)
-    @test Electrum.DataSpace(RealBasis{3}) === ByRealSpace{3}()
-    @test Electrum.DataSpace(basis(wavecar)) === ByReciprocalSpace{3}()
-    @test Electrum.DataSpace(wavecar) === ByReciprocalSpace{3}()
-    @test Electrum.DataSpace(typeof(wavecar)) === ByReciprocalSpace{3}()
+    @test Electrum.DataSpace(RealBasis{3}) === Electrum.ByRealSpace{3}()
+    @test Electrum.DataSpace(basis(wavecar)) === Electrum.ByReciprocalSpace{3}()
+    @test Electrum.DataSpace(wavecar) === Electrum.ByReciprocalSpace{3}()
+    @test Electrum.DataSpace(typeof(wavecar)) === Electrum.ByReciprocalSpace{3}()
     @test Electrum.dimension(wavecar) === 3
     @test Electrum.dimension(basis(wavecar)) === 3
     @test Electrum.dimension(typeof(wavecar)) === 3

--- a/test/internals.jl
+++ b/test/internals.jl
@@ -28,4 +28,11 @@
     @test Electrum.SUnitVector{3}(1)[:] === SVector{3,Bool}(1, 0, 0)
     @test Electrum.SUnitVector{3}(1)[1:2] == [1, 0]
     @test_throws MethodError Electrum.SUnitVector{3,Char}(1)
+    @test Electrum.DataSpace(RealBasis{3}) === ByRealSpace{3}()
+    @test Electrum.DataSpace(basis(wavecar)) === ByReciprocalSpace{3}()
+    @test Electrum.DataSpace(wavecar) === ByReciprocalSpace{3}()
+    @test Electrum.DataSpace(typeof(wavecar)) === ByReciprocalSpace{3}()
+    @test Electrum.dimension(wavecar) === 3
+    @test Electrum.dimension(basis(wavecar)) === 3
+    @test Electrum.dimension(typeof(wavecar)) === 3
 end


### PR DESCRIPTION
The `Electrum.dimension` function returns the dimension parameter associated with a `DataSpace` object. For now, this assumes that the type parameter is an integer, but in the future we may want to handle things like metric tensors which provide some notion of a number of dimensions, but are not integers themselves.

`Electrum.DataSpace` now has a new fallback when a type is given instead of an object:
```julia
DataSpace(::Type{T}) where T = DataSpace(fieldtype(T, :basis))
```
Therefore, by default, a new type with a `basis` field will automatically infer from the field's type. This can be overridden if needed for specific types.