### PR TITLE
`DataGrid` and `PlanewaveWavefunction` now subtype `DenseArray`

### DIFF
--- a/src/data/grids.jl
+++ b/src/data/grids.jl
@@ -10,7 +10,7 @@ correct_shift(k::KPoint) = k
 
 #---Struct definition------------------------------------------------------------------------------#
 """
-    Electrum.DataGrid{D,B<:LatticeBasis,S<:AbstractVector{<:Real},T} <: AbstractArray{T,D}
+    Electrum.DataGrid{D,B<:LatticeBasis,S<:AbstractVector{<:Real},T} <: DenseArray{T,D}
 
 Stores a grid of values of type `T` defined in a `D`-dimensional crystal lattice basis of type `B`
 with a shift parameter of type `S`.
@@ -34,7 +34,7 @@ Note that `ReciprocalDataGrid` uses a `KPoint{D}` to represent the shift, as opp
 `SVector{D}`. This allows for the concurrent storage of a weight along with the shift, which may be
 relevant for wavefunctions which exploit the symmetry of the k-point mesh.
 """
-struct DataGrid{D,B<:LatticeBasis,S<:AbstractVector{<:Real},T} <: AbstractArray{T,D}
+struct DataGrid{D,B<:LatticeBasis,S<:AbstractVector{<:Real},T} <: DenseArray{T,D}
     data::Array{T,D}
     basis::B
     shift::S

--- a/src/data/wavefunctions.jl
+++ b/src/data/wavefunctions.jl
@@ -116,7 +116,7 @@ Base.LinearIndices(p::PlanewaveIndices) = LinearIndices((p.grange..., p.bands, p
 =#
 
 """
-    PlanewaveWavefunction{D,T} <: AbstractArray{T,D}
+    PlanewaveWavefunction{D,T} <: DenseArray{T,D}
 
 Stores the components of a wavefunction constructed from a planewave basis. Usually, the coefficient
 data type `T` will be a `ComplexF32`, as in DFT calculations, double precision convergence of the
@@ -127,7 +127,7 @@ a `D`-dimensional `CartesianIndex` used for accessing each coefficient associate
 `PlanewaveWavefunction` instances are mutable, with `getindex()` and `setindex!()` defined for them,
 but they are not resizable, and the backing array should not be resized.
 """
-struct PlanewaveWavefunction{D,T} <: AbstractArray{T,D}
+struct PlanewaveWavefunction{D,T} <: DenseArray{T,D}
     basis::ReciprocalBasis{D,Float64}
     spins::Vector{SVector{D,Float64}}
     kpoints::KPointMesh{D}


### PR DESCRIPTION
This should not be a breaking change, but it provides a strong bound/specification on how `DataGrid` and `PlanewaveWavefunction` are implemented.