### PR TITLE
Fixes for `LatticeBasis` and `energies`/`occupancies`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
   - Increased `[compat]` minimum version of NormalForms.jl to 0.1.7
+  - `Electrum.LatticeBasis{S,D,T}` now has the type bound `S<:Electrum.BySpace` instead of the less
+concise `Union{Electrum.ByRealSpace,Electrum.ByReciprocalSpace}`.
+
+### Fixed
+  - Generic methods for `energies` and `occupancies` call the `EnergiesOccupancies` constructor 
+instead of `EnergyOccupancy`.
 
 ## [0.1.15] - 2023-11-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - Increased `[compat]` minimum version of NormalForms.jl to 0.1.7
   - `Electrum.LatticeBasis{S,D,T}` now has the type bound `S<:Electrum.BySpace` instead of the less
 concise `Union{Electrum.ByRealSpace,Electrum.ByReciprocalSpace}`.
+  - `Base.lstrip` and `Base.rstrip` are have temporarily been removed from method ambiguity testing
+(see [this PR](https://github.com/JuliaStrings/InlineStrings.jl/pull/70) for InlineStrings.jl)
 
 ### Fixed
   - Generic methods for `energies` and `occupancies` call the `EnergiesOccupancies` constructor 

--- a/src/data/energies.jl
+++ b/src/data/energies.jl
@@ -40,7 +40,7 @@ Returns the energy data associated with a collection of `EnergyOccupancy{T}` obj
 this falls back to `energy.(EnergyOccupancy(x))`.
 """
 energies(a::AbstractArray{<:EnergyOccupancy}) = energy.(a)
-energies(x) = energy.(EnergyOccupancy(x))
+energies(x) = energy.(EnergiesOccupancies(x))
 
 """
     occupancies(x) -> Array{<:Real}
@@ -49,7 +49,7 @@ Returns the occupancy data associated with a collection of `EnergyOccupancy{T}` 
 this falls back to `occupancy.(EnergyOccupancy(x))`.
 """
 occupancies(a::AbstractArray{<:EnergyOccupancy}) = occupancy.(a)
-occupancies(x) = occupancy.(EnergyOccupancy(x))
+occupancies(x) = occupancy.(EnergiesOccupancies(x))
 
 """
     min_energy(x) -> Real

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -43,7 +43,7 @@ In order to avoid the presence of an extraneous type parameter, the backing `vec
 `SMatrix{D,D,T}`. The `vectors` property is private, and will not be revealed during REPL tab
 completion.
 """
-struct LatticeBasis{S<:Union{ByRealSpace,ByReciprocalSpace},D,T<:Real} <: StaticMatrix{D,D,T}
+struct LatticeBasis{S<:BySpace,D,T<:Real} <: StaticMatrix{D,D,T}
     vectors::SVector{D,SVector{D,T}}
     function LatticeBasis{S,D,T}(M::StaticMatrix) where {S,D,T}
         lattice_sanity_check(M)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Test, Aqua, Electrum
 
 tmpdir = mktempdir()
 
-excluded_methods = Function[Base.unsafe_convert]
+excluded_methods = Function[Base.unsafe_convert, Base.lstrip, Base.rstrip]
 # Base.getindex ambiguity was resolved in 1.9:
 # https://github.com/JuliaLang/julia/pull/41807
 # TODO: can we still try to test other methods for Base.getindex? It's pretty important...

--- a/test/wavefunctions.jl
+++ b/test/wavefunctions.jl
@@ -20,6 +20,8 @@
     # Energies and occupancies
     @test wavecar.energies == energies(EnergiesOccupancies(wavecar))
     @test wavecar.occupancies == occupancies(EnergiesOccupancies(wavecar))
+    @test wavecar.energies == energies(wavecar)
+    @test wavecar.ocupancies == occupancies(wavecar)
     @test min_energy(wavecar) == minimum(wavecar.energies)
     @test max_energy(wavecar) == maximum(wavecar.energies)
     @test min_energy(wavecar) == min_energy(EnergiesOccupancies(wavecar))

--- a/test/wavefunctions.jl
+++ b/test/wavefunctions.jl
@@ -21,7 +21,7 @@
     @test wavecar.energies == energies(EnergiesOccupancies(wavecar))
     @test wavecar.occupancies == occupancies(EnergiesOccupancies(wavecar))
     @test wavecar.energies == energies(wavecar)
-    @test wavecar.ocupancies == occupancies(wavecar)
+    @test wavecar.occupancies == occupancies(wavecar)
     @test min_energy(wavecar) == minimum(wavecar.energies)
     @test max_energy(wavecar) == maximum(wavecar.energies)
     @test min_energy(wavecar) == min_energy(EnergiesOccupancies(wavecar))


### PR DESCRIPTION
It appears I had the wrong definitions for `energies` and `occupancies` on generic objects, so that's been fixed.

`Electrum.LatticeBasis{S}` now has `S` subtype `Electrum.BySpace` instead of `Union{Electrum.ByRealSpace,Electrum.ByReciprocalSpace}`. 