### PR TITLE
New `Multiplicity{M}` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
   - `[compat]` bounds are now provided for testing dependencies (Aqua.jl, Test.jl, TOML.jl).
-  - New `SpinRange{M}` type for valid spin values associated with multiplicity `M`.
+  - New `Multiplicity{M}` type for valid spin values associated with multiplicity `M`.
 
 ### Changed
   - Increased `[compat]` minimum version of NormalForms.jl to 0.1.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
   - `[compat]` bounds are now provided for testing dependencies (Aqua.jl, Test.jl, TOML.jl).
+  - New `SpinRange{M}` type for valid spin values associated with multiplicity `M`.
 
 ### Changed
   - Increased `[compat]` minimum version of NormalForms.jl to 0.1.7

--- a/docs/src/api/data.md
+++ b/docs/src/api/data.md
@@ -34,6 +34,11 @@ Electrum.nkpt
 Electrum.weight
 ```
 
+## Spin states
+```@docs
+Electrum.SpinRange
+```
+
 ## Energies and occupancies
 ```@docs
 Electrum.EnergyOccupancy

--- a/docs/src/api/data.md
+++ b/docs/src/api/data.md
@@ -36,7 +36,7 @@ Electrum.weight
 
 ## Spin states
 ```@docs
-Electrum.SpinRange
+Electrum.Multiplicity
 ```
 
 ## Energies and occupancies

--- a/src/Electrum.jl
+++ b/src/Electrum.jl
@@ -135,7 +135,7 @@ export EnergyOccupancy, EnergiesOccupancies
 export energy, occupancy, energies, occupancies, min_energy, max_energy, min_occupancy,
     max_occupancy, fermi
 include("data/spin.jl")
-export SpinRange
+export Multiplicity
 # Real and reciprocal space data grids
 include("data/grids.jl")
 export DataGrid, RealDataGrid, ReciprocalDataGrid

--- a/src/Electrum.jl
+++ b/src/Electrum.jl
@@ -134,6 +134,8 @@ include("data/energies.jl")
 export EnergyOccupancy, EnergiesOccupancies
 export energy, occupancy, energies, occupancies, min_energy, max_energy, min_occupancy,
     max_occupancy, fermi
+include("data/spin.jl")
+export SpinRange
 # Real and reciprocal space data grids
 include("data/grids.jl")
 export DataGrid, RealDataGrid, ReciprocalDataGrid

--- a/src/data/spin.jl
+++ b/src/data/spin.jl
@@ -1,0 +1,37 @@
+"""
+    SpinRange{M} <: AbstractUnitRange{Rational{Int}}
+
+Represents a valid range of spin states corresponding with multiplicity `M`. These are equivalent to 
+`UnitRange{Rational{Int}}` objects of the form `-(M - 1)//2:(M - 1)//2`.
+
+These types are singleton types with a numeric `Int` parameter, allowing for its use as a dispatch
+type.
+
+# Examples
+```
+julia> SpinRange{3}() == -1:1
+true
+
+julia> SpinRange{4}() == -3//2:3//2
+true
+```
+"""
+struct SpinRange{M} <: AbstractUnitRange{Rational{Int}}
+    SpinRange{M}() where M = (@assert M > 0 "M must be a positive integer."; new{Int(M)}())
+end
+
+SpinRange(M) = SpinRange{Int(M)}()
+
+Base.size(::SpinRange{M}) where M = M
+Base.first(::SpinRange{M}) where M = -(M-1)//2
+Base.last(::SpinRange{M}) where M = (M-1)//2
+Base.getindex(s::SpinRange{M}, i::Integer) where M = first(s) + (i - 1)
+
+Base.UnitRange(::SpinRange) = first(s):last(s)
+Base.convert(T::Type{<:AbstractVector}, s::SpinRange) = convert(T, UnitRange(s))
+Base.show(io::IO, s::SpinRange) = print(io, typeof(s), "()")
+
+function Base.show(io::IO, ::MIME"text/plain", s::SpinRange)
+    show(io, s)
+    print(io, " (equivalent to ", UnitRange(s), ")")
+end

--- a/src/data/spin.jl
+++ b/src/data/spin.jl
@@ -21,6 +21,12 @@ struct Multiplicity{M} <: AbstractUnitRange{Rational{Int}}
     Multiplicity{M}() where M = (@assert M > 0 "M must be a positive integer."; new{Int(M)}())
 end
 
+"""
+    Multiplicity(M)
+
+Constructs `Multiplicity{M}()`. This function is not type-stable unless the value of `M` is known at
+compile time, similar to `Val(M)`.
+"""
 Multiplicity(M) = Multiplicity{Int(M)}()
 
 Base.size(::Multiplicity{M}) where M = M

--- a/src/data/spin.jl
+++ b/src/data/spin.jl
@@ -39,8 +39,3 @@ end
 
 Base.UnitRange(s::Multiplicity) = first(s):last(s)
 Base.show(io::IO, s::Multiplicity) = print(io, typeof(s), "()")
-
-function Base.show(io::IO, ::MIME"text/plain", s::Multiplicity)
-    show(io, s)
-    print(io, " (equivalent to ", UnitRange(s), ")")
-end

--- a/src/data/spin.jl
+++ b/src/data/spin.jl
@@ -29,7 +29,6 @@ Base.last(::Multiplicity{M}) where M = (M-1)//2
 Base.getindex(s::Multiplicity{M}, i::Integer) where M = first(s) + (i - 1)
 
 Base.UnitRange(::Multiplicity) = first(s):last(s)
-Base.convert(T::Type{<:AbstractVector}, s::Multiplicity) = convert(T, UnitRange(s))
 Base.show(io::IO, s::Multiplicity) = print(io, typeof(s), "()")
 
 function Base.show(io::IO, ::MIME"text/plain", s::Multiplicity)

--- a/src/data/spin.jl
+++ b/src/data/spin.jl
@@ -28,7 +28,7 @@ Base.first(::Multiplicity{M}) where M = -(M-1)//2
 Base.last(::Multiplicity{M}) where M = (M-1)//2
 Base.getindex(s::Multiplicity{M}, i::Integer) where M = first(s) + (i - 1)
 
-Base.UnitRange(::Multiplicity) = first(s):last(s)
+Base.UnitRange(s::Multiplicity) = first(s):last(s)
 Base.show(io::IO, s::Multiplicity) = print(io, typeof(s), "()")
 
 function Base.show(io::IO, ::MIME"text/plain", s::Multiplicity)

--- a/src/data/spin.jl
+++ b/src/data/spin.jl
@@ -1,37 +1,38 @@
 """
-    SpinRange{M} <: AbstractUnitRange{Rational{Int}}
+    Multiplicity{M} <: AbstractUnitRange{Rational{Int}}
 
-Represents a valid range of spin states corresponding with multiplicity `M`. These are equivalent to 
-`UnitRange{Rational{Int}}` objects of the form `-(M - 1)//2:(M - 1)//2`.
+Represents a valid range of spin states corresponding with multiplicity `M`. These index as if they 
+are `UnitRange{Rational{Int}}` objects of the form `-(M - 1)//2:(M - 1)//2`, and can be converted to
+`UnitRange` objects with the `UnitRange` constructor.
 
-These types are singleton types with a numeric `Int` parameter, allowing for its use as a dispatch
-type.
+These types are singleton types with a numeric `Int` parameter, allowing for its use as a type
+parameter in other types which require information on the spin multiplicity or allowed spin states.
 
 # Examples
 ```
-julia> SpinRange{3}() == -1:1
-true
+julia> UnitRange(SpinRange{3}())
+1:1
 
 julia> SpinRange{4}() == -3//2:3//2
 true
 ```
 """
-struct SpinRange{M} <: AbstractUnitRange{Rational{Int}}
-    SpinRange{M}() where M = (@assert M > 0 "M must be a positive integer."; new{Int(M)}())
+struct Multiplicity{M} <: AbstractUnitRange{Rational{Int}}
+    Multiplicity{M}() where M = (@assert M > 0 "M must be a positive integer."; new{Int(M)}())
 end
 
-SpinRange(M) = SpinRange{Int(M)}()
+Multiplicity(M) = Multiplicity{Int(M)}()
 
-Base.size(::SpinRange{M}) where M = M
-Base.first(::SpinRange{M}) where M = -(M-1)//2
-Base.last(::SpinRange{M}) where M = (M-1)//2
-Base.getindex(s::SpinRange{M}, i::Integer) where M = first(s) + (i - 1)
+Base.size(::Multiplicity{M}) where M = M
+Base.first(::Multiplicity{M}) where M = -(M-1)//2
+Base.last(::Multiplicity{M}) where M = (M-1)//2
+Base.getindex(s::Multiplicity{M}, i::Integer) where M = first(s) + (i - 1)
 
-Base.UnitRange(::SpinRange) = first(s):last(s)
-Base.convert(T::Type{<:AbstractVector}, s::SpinRange) = convert(T, UnitRange(s))
-Base.show(io::IO, s::SpinRange) = print(io, typeof(s), "()")
+Base.UnitRange(::Multiplicity) = first(s):last(s)
+Base.convert(T::Type{<:AbstractVector}, s::Multiplicity) = convert(T, UnitRange(s))
+Base.show(io::IO, s::Multiplicity) = print(io, typeof(s), "()")
 
-function Base.show(io::IO, ::MIME"text/plain", s::SpinRange)
+function Base.show(io::IO, ::MIME"text/plain", s::Multiplicity)
     show(io, s)
     print(io, " (equivalent to ", UnitRange(s), ")")
 end

--- a/src/data/spin.jl
+++ b/src/data/spin.jl
@@ -26,7 +26,10 @@ Multiplicity(M) = Multiplicity{Int(M)}()
 Base.size(::Multiplicity{M}) where M = M
 Base.first(::Multiplicity{M}) where M = -(M-1)//2
 Base.last(::Multiplicity{M}) where M = (M-1)//2
-Base.getindex(s::Multiplicity{M}, i::Integer) where M = first(s) + (i - 1)
+
+@inbounds function Base.getindex(s::Multiplicity, i::Integer)
+    return i in eachindex(s) ? first(s) + (i - 1) : throw(BoundsError(s, i))
+end
 
 Base.UnitRange(s::Multiplicity) = first(s):last(s)
 Base.show(io::IO, s::Multiplicity) = print(io, typeof(s), "()")

--- a/src/data/spin.jl
+++ b/src/data/spin.jl
@@ -29,7 +29,7 @@ compile time, similar to `Val(M)`.
 """
 Multiplicity(M) = Multiplicity{Int(M)}()
 
-Base.size(::Multiplicity{M}) where M = M
+Base.size(::Multiplicity{M}) where M = (M,)
 Base.first(::Multiplicity{M}) where M = -(M-1)//2
 Base.last(::Multiplicity{M}) where M = (M-1)//2
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -192,7 +192,7 @@ function Base.show(io::IO, ::MIME"text/plain", l::AbstractAtomList; kwargs...)
     end
 end
 
-#---Types from data/reciprocalspace.jl-------------------------------------------------------------#
+#---Types from data/kpoints.jl========-------------------------------------------------------------#
 
 Base.summary(io::IO, k::KPoint) = print(io, typeof(k), " with weight ", k.weight)
 
@@ -204,6 +204,13 @@ end
 
 function Base.summary(io::IO, k::KPointMesh)
     print(io, length(k), "-element ", typeof(k), " (total weight ", sum(weight.(k)), ')')
+end
+
+#---Types from data/spin.jl------------------------------------------------------------------------#
+
+function Base.show(io::IO, ::MIME"text/plain", s::Multiplicity)
+    show(io, s)
+    print(io, " (equivalent to ", UnitRange(s), ")")
 end
 
 #---Types from data/grids.jl-----------------------------------------------------------------------#

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,5 +39,6 @@ lammps = read_lammps_data("files/lammps.data", atom_types = [14, 77])
     include("crystals.jl")
     include("filetypes.jl")
     include("kpoints.jl")
+    include("spin.jl")
     include("wavefunctions.jl")
 end

--- a/test/spin.jl
+++ b/test/spin.jl
@@ -1,10 +1,13 @@
 @testset "Spin" begin
-    @test all(last(SpinRange(n)) == (n - 1)//2 for n in 1:100)
-    @test all(SpinRange(n)[2] == (n - 1)//2 + 1 for n in 2:100)
-    @test all(iszero(last(SpinRange(n)) + first(SpinRange(n))) for n in 1:100)
-    @test all(SpinRange(n) == UnitRange(SpinRange(n)) for n in 1:100)
-    @test all(UnitRange(SpinRange(n)) === first(SpinRange(n)):last(SpinRange(n)) for n in 1:100)
-    @test all(SpinRange(n)[2] == UnitRange(SpinRange(n))[2] for n in 2:100)
-    @test_throws AssertionError SpinRange{0}()
-    @test_throws AssertionError SpinRange(0)
+    @test all(last(Multiplicity(n)) == (n - 1)//2 for n in 1:100)
+    @test all(Multiplicity(n)[2] == (n - 1)//2 + 1 for n in 2:100)
+    @test all(iszero(last(Multiplicity(n)) + first(Multiplicity(n))) for n in 1:100)
+    @test all(Multiplicity(n) == UnitRange(Multiplicity(n)) for n in 1:100)
+    @test all(
+        UnitRange(Multiplicity(n)) === first(Multiplicity(n)):last(Multiplicity(n)) 
+        for n in 1:100
+    )
+    @test all(Multiplicity(n)[2] == UnitRange(Multiplicity(n))[2] for n in 2:100)
+    @test_throws AssertionError Multiplicity{0}()
+    @test_throws AssertionError Multiplicity(0)
 end

--- a/test/spin.jl
+++ b/test/spin.jl
@@ -8,6 +8,13 @@
         for n in 1:100
     )
     @test all(Multiplicity(n)[2] == UnitRange(Multiplicity(n))[2] for n in 2:100)
+    @test_throws BoundsError Multiplicity{3}()[0]
+    @test_throws BoundsError Multiplicity{3}()[4]
+    # Constructor robustness
+    @test Multiplicity(1) === Multiplicity{1}()
+    @test Multiplicity(1.0) === Multiplicity{1}()
     @test_throws AssertionError Multiplicity{0}()
     @test_throws AssertionError Multiplicity(0)
+    @test_throws AssertionError Multiplicity{1/2}()
+    @test_throws AssertionError Multiplicity(1/2)
 end

--- a/test/spin.jl
+++ b/test/spin.jl
@@ -15,6 +15,6 @@
     @test Multiplicity(1.0) === Multiplicity{1}()
     @test_throws AssertionError Multiplicity{0}()
     @test_throws AssertionError Multiplicity(0)
-    @test_throws AssertionError Multiplicity{1/2}()
-    @test_throws AssertionError Multiplicity(1/2)
+    @test_throws InexactError Multiplicity{1/2}()
+    @test_throws InexactError Multiplicity(1/2)
 end

--- a/test/spin.jl
+++ b/test/spin.jl
@@ -1,5 +1,5 @@
 @testset "Spin" begin
-    @test all(size(Multiplicity(n)) == n for n in 1:100)
+    @test all(size(Multiplicity(n)) == (n,) for n in 1:100)
     @test all(last(Multiplicity(n)) == (n - 1)//2 for n in 1:100)
     @test all(Multiplicity(n)[2] == -(n - 1)//2 + 1 for n in 2:100)
     @test all(iszero(last(Multiplicity(n)) + first(Multiplicity(n))) for n in 1:100)

--- a/test/spin.jl
+++ b/test/spin.jl
@@ -1,4 +1,5 @@
 @testset "Spin" begin
+    @test all(size(Multiplicity(n)) == n for n in 1:100)
     @test all(last(Multiplicity(n)) == (n - 1)//2 for n in 1:100)
     @test all(Multiplicity(n)[2] == -(n - 1)//2 + 1 for n in 2:100)
     @test all(iszero(last(Multiplicity(n)) + first(Multiplicity(n))) for n in 1:100)
@@ -17,4 +18,6 @@
     @test_throws AssertionError Multiplicity(0)
     @test_throws InexactError Multiplicity{1/2}()
     @test_throws InexactError Multiplicity(1/2)
+    # Text representation
+    @test eval(Meta.parse(repr(Multiplicity(3)))) === Multiplicity(3)
 end

--- a/test/spin.jl
+++ b/test/spin.jl
@@ -1,6 +1,6 @@
 @testset "Spin" begin
     @test all(last(Multiplicity(n)) == (n - 1)//2 for n in 1:100)
-    @test all(Multiplicity(n)[2] == (n - 1)//2 + 1 for n in 2:100)
+    @test all(Multiplicity(n)[2] == -(n - 1)//2 + 1 for n in 2:100)
     @test all(iszero(last(Multiplicity(n)) + first(Multiplicity(n))) for n in 1:100)
     @test all(Multiplicity(n) == UnitRange(Multiplicity(n)) for n in 1:100)
     @test all(

--- a/test/spin.jl
+++ b/test/spin.jl
@@ -1,0 +1,10 @@
+@testset "Spin" begin
+    @test all(last(SpinRange(n)) == (n - 1)//2 for n in 1:100)
+    @test all(SpinRange(n)[2] == (n - 1)//2 + 1 for n in 2:100)
+    @test all(iszero(last(SpinRange(n)) + first(SpinRange(n))) for n in 1:100)
+    @test all(SpinRange(n) == UnitRange(SpinRange(n)) for n in 1:100)
+    @test all(UnitRange(SpinRange(n)) === first(SpinRange(n)):last(SpinRange(n)) for n in 1:100)
+    @test all(SpinRange(n)[2] == UnitRange(SpinRange(n))[2] for n in 2:100)
+    @test_throws AssertionError SpinRange{0}()
+    @test_throws AssertionError SpinRange(0)
+end


### PR DESCRIPTION
This type should facilitate indexing of some new data types by spin state. `SpinRange{M}` has a single type parameter, the multiplicity `M`, which is an `Int`, and it behaves like `UnitRange(-(M-1)//2, (M-1)//2)`, where all elements are valid angular momenta for that multiplicity.

I am willing to go back and rename this type to `Multiplicity` or something else, because even though `SpinRange` is an `AbstractUnitRange`, the type parameter `M` is the spin multiplicity.