### PR TITLE
`eachvertex` iterator for `RealBasis`, `ReciprocalBasis`, and even `AbstractMatrix` types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+  - `eachvertex` iterator for the vertices of the parallelepiped representation of a unit cell.
+
 ## [0.1.16]: 2023-11-16
 
 ### Added

--- a/docs/src/api/lattices.md
+++ b/docs/src/api/lattices.md
@@ -9,6 +9,7 @@ Electrum.AbstractBasis
 
 ## Methods
 ```@docs
+Electrum.eachvertex
 Electrum.basis
 Electrum.lengths(::Electrum.LatticeBasis)
 Electrum.volume(::Electrum.LatticeBasis)

--- a/src/Electrum.jl
+++ b/src/Electrum.jl
@@ -113,8 +113,8 @@ include("traits.jl")
 # Methods and structs for working with crystal lattices
 include("lattices.jl")
 export RealBasis, ReciprocalBasis, AbstractBasis
-export basis, lengths, volume, angles_cos, angles_rad, angles_deg, gram, isdiag, qr, triangularize, 
-    maxHKLindex
+export eachvertex, basis, lengths, volume, angles_cos, angles_rad, angles_deg, gram, isdiag, qr,
+    triangularize, maxHKLindex
 # Methods and structs for working with atomic positions
 include("atoms.jl")
 export NamedAtom, AbstractAtomPosition, FractionalAtomPosition, CartesianAtomPosition,

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -147,7 +147,7 @@ recommend working with static matrix types like the provided `RealBasis` and `Re
 eachvertex(m::StaticMatrix{<:Any,D,T}) where {D,T} = eachvertex(m, fill(T.(0:1), SVector{D})...)
 # Needs to be done differently because the design above leads to type instability
 function eachvertex(m::AbstractMatrix)
-    return (m * [!iszero((i-1) & 2^(n-1)) for n in axes(b, 2)] for i in 1:2^size(b, 2))
+    return (m * [!iszero((i-1) & 2^(n-1)) for n in axes(m, 2)] for i in 1:2^size(m, 2))
 end
 
 #---Conversion semantics---------------------------------------------------------------------------#

--- a/test/lattices.jl
+++ b/test/lattices.jl
@@ -17,4 +17,19 @@
     @test promote_type(RealBasis{3,Int64}, ReciprocalBasis{3,Float32}) === SMatrix{3,3,Float32,9}
     # Metrics
     @test all(x == Electrum.ANG2BOHR for x in lengths(b))
+    # eachvertex iterator
+    @test isequal(
+        Electrum._gen_vertices(reshape(1:69, 23, 3), 1:420),
+        Electrum._gen_vertices(1:69, reshape(1:420, 3, 35, 4))
+    )
+    @test collect(eachvertex([6 0; 0 9])) == vec(collect(eachvertex(SMatrix{2,2}(6, 0, 0, 1))))
+    result = SVector{3,Float64}[
+        [0, 0, 0], [1, 0, 0], [0, 2, 0], [1, 2, 0],
+        [0, 0, 3], [1, 0, 3], [0, 2, 3], [1, 2, 3]
+    ]
+    @test all(isequal.(eachvertex(diagm([1, 2, 3])), result))
+    @test isequal(
+        collect(eachvertex(SMatrix{3,3}(diagm([1, 2, 3])))),
+        reshape(result, 2, 2, 2)
+    )
 end

--- a/test/lattices.jl
+++ b/test/lattices.jl
@@ -19,10 +19,10 @@
     @test all(x == Electrum.ANG2BOHR for x in lengths(b))
     # eachvertex iterator
     @test isequal(
-        Electrum._gen_vertices(reshape(1:69, 23, 3), 1:420),
-        Electrum._gen_vertices(1:69, reshape(1:420, 3, 35, 4))
+        Electrum._gen_vertices((reshape(1:69, 23, 3), 1:420)),
+        Electrum._gen_vertices((1:69, reshape(1:420, 3, 35, 4)))
     )
-    @test collect(eachvertex([6 0; 0 9])) == vec(collect(eachvertex(SMatrix{2,2}(6, 0, 0, 1))))
+    @test collect(eachvertex([6 0; 0 9])) == vec(collect(eachvertex(SMatrix{2,2}(6, 0, 0, 9))))
     result = SVector{3,Float64}[
         [0, 0, 0], [1, 0, 0], [0, 2, 0], [1, 2, 0],
         [0, 0, 3], [1, 0, 3], [0, 2, 3], [1, 2, 3]

--- a/test/lattices.jl
+++ b/test/lattices.jl
@@ -23,6 +23,7 @@
         Electrum._gen_vertices((1:69, reshape(1:420, 3, 35, 4)))
     )
     @test collect(eachvertex([6 0; 0 9])) == vec(collect(eachvertex(SMatrix{2,2}(6, 0, 0, 9))))
+    @test all(eachvertex(0:1, 0:1) .== SVector{2,Int}.([(0, 0) (0, 1); (1,0) (1,1)]))
     result = SVector{3,Float64}[
         [0, 0, 0], [1, 0, 0], [0, 2, 0], [1, 2, 0],
         [0, 0, 3], [1, 0, 3], [0, 2, 3], [1, 2, 3]


### PR DESCRIPTION
This iterator should let a user run through each vertex of the parallelepiped spanned by the basis vectors of a lattice given by an `AbstractMatrix`.