### PR TITLE
`inv(::LatticeBasis)` should return the matrix inverse, not the dual lattice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
   - `eachvertex` iterator for the vertices of the parallelepiped representation of a unit cell.
   - `SpinBivector` type representing spin direction in a dimension-agnostic way.
+  - `dual(b::LatticeBasis)` returns the dual lattice associated with `b`.
+  - `dualbasis(x)` returns the dual lattice basis vectors associated with `x`.
 
 ### Changed
   - The Types section of the documentation has been split up into separate sections for lattice
@@ -18,6 +20,7 @@ basis vectors, atoms and crystal representations, and data grids.
 ### Fixed
   - The default definition of `Electrum.DataSpace(x)` is now `DataSpace(typeof(x))`, not
 `DataSpace(typeof(basis(x)))`.
+  - `inv(b::LatticeBasis)` returns the matrix inverse of `b`, not the dual lattice basis.
 
 ## [0.1.16]: 2023-11-16
 

--- a/docs/src/api/lattices.md
+++ b/docs/src/api/lattices.md
@@ -11,6 +11,9 @@ Electrum.AbstractBasis
 ```@docs
 Electrum.eachvertex
 Electrum.basis
+Base.inv(::Electrum.LatticeBasis)
+Electrum.dual
+Electrum.dualbasis
 Electrum.lengths(::Electrum.LatticeBasis)
 Electrum.volume(::Electrum.LatticeBasis)
 Electrum.angles_cos

--- a/src/Electrum.jl
+++ b/src/Electrum.jl
@@ -113,8 +113,8 @@ include("traits.jl")
 # Methods and structs for working with crystal lattices
 include("lattices.jl")
 export RealBasis, ReciprocalBasis, AbstractBasis
-export eachvertex, basis, lengths, volume, angles_cos, angles_rad, angles_deg, gram, isdiag, qr,
-    triangularize, maxHKLindex
+export eachvertex, basis, dual, dualbasis, lengths, volume, angles_cos, angles_rad, angles_deg, 
+    gram, isdiag, qr, triangularize, maxHKLindex
 # Methods and structs for working with atomic positions
 include("atoms.jl")
 export NamedAtom, AbstractAtomPosition, FractionalAtomPosition, CartesianAtomPosition,

--- a/src/data/grids.jl
+++ b/src/data/grids.jl
@@ -302,7 +302,7 @@ fftvol(g::DataGrid{D,<:ReciprocalBasis}) where D = det(basis(g).matrix / 2π)
 
 Performs a fast Fourier transform on the data in a `DataGrid`.
 """
-FFTW.fft(g::DataGrid) = DataGrid(fft(g.data) * fftvol(g), inv(basis(g)))
+FFTW.fft(g::DataGrid) = DataGrid(fft(g.data) * fftvol(g), dualbasis(g))
 
 """
     ifft(g::RealDataGrid) -> ReciprocalDataGrid
@@ -312,7 +312,7 @@ Performs an inverse fast Fourier transform on the data in a `DataGrid`.
 
 The inverse FFT is normalized so that `ifft(fft(g)) ≈ g` (to within floating point error).
 """
-FFTW.ifft(g::DataGrid) = DataGrid(bfft(g.data) * fftvol(g), inv(basis(g)))
+FFTW.ifft(g::DataGrid) = DataGrid(bfft(g.data) * fftvol(g), dualbasis(g))
 
 function FFTW.fftfreq(g::DataGrid, ::ByRealSpace)
     return map(i -> SVector(2π .* Tuple(i) ./ size(g)), FFTBins(g))

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -215,6 +215,25 @@ Base.:(==)(a::LatticeBasis{S,D}, b::LatticeBasis{S,D}) where {S,D} = a.matrix ==
 Base.inv(b::RealBasis) = convert(ReciprocalBasis, b)
 Base.inv(b::ReciprocalBasis) = convert(RealBasis, b)
 
+"""
+    dual(b::RealBasis) -> ReciprocalBasis
+    dual(b::ReciprocalBasis) -> RealBasis
+
+Returns the basis of the dual lattice, which is the lattice in dual space whose product with the
+original lattice is equal to the identity matrix multiplied by 2π.
+"""
+dual(b::LatticeBasis{S}) where S = convert(LatticeBasis{inverse_space(S)}, b)
+
+"""
+    dualbasis(x)
+
+Returns the dual basis associated with a data structure `x`; equal to `dual(basis(x))`.
+
+This function should never be defined directly: instead, `basis(::T)` should be implemented for a
+custom type `T`.
+"""
+dualbasis(x) = dual(basis(x))
+
 #= Scalars
 Base.:*(s::Real, b::LatticeBasis) = typeof(b)(s .* b.vectors)
 Base.:*(b::LatticeBasis, s::Real) = s * b

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -212,8 +212,16 @@ end
 
 Base.:(==)(a::LatticeBasis{S,D}, b::LatticeBasis{S,D}) where {S,D} = a.matrix == b.matrix
 
-Base.inv(b::RealBasis) = convert(ReciprocalBasis, b)
-Base.inv(b::ReciprocalBasis) = convert(RealBasis, b)
+"""
+    inv(b::LatticeBasis{D}) -> SMatrix{D,D}
+
+Returns the matrix which, when left or right multiplied by `b`, returns the identity matrix, up to
+rounding error. Because the result of this calculation is not the dual lattice associated with `b`,
+the return type is simply an `SMatrix{D,D}`.
+
+For the dual space lattice basis vectors, use [`dual(x)`](@ref) or [`dualbasis(x)`](@ref).
+"""
+Base.inv(b::LatticeBasis) = inv(b.matrix)
 
 """
     dual(b::RealBasis) -> ReciprocalBasis

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -49,6 +49,30 @@ struct ByReciprocalSpace{D} <: BySpace{D}
 end
 
 """
+    Electrum.inverse_space(::Type{<:BySpace}) -> Type{<:BySpace}
+    Electrum.inverse_space(::BySpace) -> BySpace
+
+Returns the space trait dual to the given space trait. Either a type or an instance may be given.
+
+# Examples
+```julia-repl
+julia> Electrum.inverse_space(Electrum.ByReciprocalSpace)
+Electrum.ByRealSpace
+
+julia> Electrum.inverse_space(Electrum.ByRealSpace{3})
+Electrum.ByReciprocalSpace{3}
+
+julia> Electrum.inverse_space(Electrum.ByRealSpace{3}())
+Electrum.ByReciprocalSpace{3}()
+```
+"""
+inverse_space(::Type{ByRealSpace}) = ByReciprocalSpace
+inverse_space(::Type{ByReciprocalSpace}) = ByRealSpace
+inverse_space(::Type{ByRealSpace{D}}) where D = ByReciprocalSpace{D}
+inverse_space(::Type{ByReciprocalSpace{D}}) where D = ByRealSpace{D}
+inverse_space(::T) where T<:BySpace = inverse_space(T)()
+
+"""
     Electrum.DataSpace(x) -> DataSpace
 
 Returns a trait that determines whether a data set associated with a crystal is defined in real

--- a/test/internals.jl
+++ b/test/internals.jl
@@ -28,10 +28,17 @@
     @test Electrum.SUnitVector{3}(1)[:] === SVector{3,Bool}(1, 0, 0)
     @test Electrum.SUnitVector{3}(1)[1:2] == [1, 0]
     @test_throws MethodError Electrum.SUnitVector{3,Char}(1)
+    # Traits
     @test Electrum.DataSpace(RealBasis{3}) === Electrum.ByRealSpace{3}()
     @test Electrum.DataSpace(basis(wavecar)) === Electrum.ByReciprocalSpace{3}()
     @test Electrum.DataSpace(wavecar) === Electrum.ByReciprocalSpace{3}()
     @test Electrum.DataSpace(typeof(wavecar)) === Electrum.ByReciprocalSpace{3}()
+    @test Electrum.inverse_space(Electrum.ByRealSpace) === Electrum.ByReciprocalSpace
+    @test Electrum.inverse_space(Electrum.ByReciprocalSpace) === Electrum.ByRealSpace
+    @test Electrum.inverse_space(Electrum.ByRealSpace{3}) === Electrum.ByReciprocalSpace{3}
+    @test Electrum.inverse_space(Electrum.ByReciprocalSpace{3}) === Electrum.ByRealSpace{3}
+    @test Electrum.inverse_space(Electrum.ByRealSpace{3}()) === Electrum.ByReciprocalSpace{3}()
+    @test Electrum.inverse_space(Electrum.ByReciprocalSpace{3}()) === Electrum.ByRealSpace{3}()
     @test Electrum.dimension(wavecar) === 3
     @test Electrum.dimension(basis(wavecar)) === 3
     @test Electrum.dimension(typeof(wavecar)) === 3

--- a/test/lattices.jl
+++ b/test/lattices.jl
@@ -10,6 +10,13 @@
     # Wrong dimensionality should throw an exception
     @test_throws DimensionMismatch RealBasis{3}([1 0; 0 1])
     @test_throws DimensionMismatch convert(ReciprocalBasis{2}, b)
+    # Matrix inverse of lattice is not the dual lattice
+    @test inv(b) === inv(b.matrix)
+    @test dual(b) === convert(ReciprocalBasis, b)
+    @test dual(b) === ReciprocalBasis(b)
+    @test dualbasis(xsf["this_is_3Dgrid#1"]) === dual(b)
+    @test inv(b) * b ≈ diagm(ones(SVector{3}))
+    @test dual(b) * b ≈ diagm(fill(2π, SVector{3}))
     # Gram matrix test
     @test gram(b) === (M = convert(SMatrix, b); M' * M)
     # Type promotion


### PR DESCRIPTION
The new `dual` and `dualbasis` functions should return the dual lattice as needed.