### PR TITLE
`BySpace` and `ByCoordinate` traits have been refactored and exported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ energy provided.
   - `ByCoordinate` traits: `ByCartesianCoordinate` and `ByFractionalCoordinate`.
   - `ShiftVector{S,D,T} <: StaticVector{D,T}` type describing the shift of a lattice or data defined
 on it with respect to the origin, along with an optional weight parameter.
+  - `require_same_space`, `require_dual_space`, and `require_same_coordinate` functions for checking
+whether `BySpace` and `ByCoordinate` traits are compatible in an operation.
 
 ### Changed
   - `BySpace` traits are now part of the public API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,10 @@ whether `BySpace` and `ByCoordinate` traits are compatible in an operation.
 
 ### Changed
   - `BySpace` traits are now part of the public API.
-  - `BySpace(x)` replaces `Electrum.DataSpace(x)`.
   - `BySpace{D}` and its subtypes have lost their dimension type parameter.
+
+### Removed
+  - `Electrum.DataSpace(x)` has been replaced with `BySpace(x)`.
 
 ## [0.1.17]: 2023-11-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
   - `StateDensity{T}` type which combines `EnergyOccupancy{T}` with a density of states value at the
 energy provided.
-  - `ByCoordinate{D}` traits: `ByCartesianCoordinate{D}` and `ByFractionalCoordinate{D}`.
+  - `ByCoordinate` traits: `ByCartesianCoordinate` and `ByFractionalCoordinate`.
   - `ShiftVector{S,D,T} <: StaticVector{D,T}` type describing the shift of a lattice or data defined
 on it with respect to the origin, along with an optional weight parameter.
+
+### Changed
+  - `BySpace` traits are now part of the public API.
+  - `BySpace(x)` replaces `Electrum.DataSpace(x)`.
+  - `BySpace{D}` and its subtypes have lost their dimension type parameter.
 
 ## [0.1.17]: 2023-11-29
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,6 +20,7 @@ makedocs(
         "Data grids" => "grids.md",
         "File formats" => "filetypes.md",
         "API" => Any[
+            "Traits" => "api/traits.md"
             "Geometry" => "api/geometry.md"
             "Atoms" => "api/atoms.md"
             "Crystals" => "api/crystals.md"

--- a/docs/src/api/traits.md
+++ b/docs/src/api/traits.md
@@ -1,0 +1,17 @@
+# Traits
+
+## Space traits
+
+```@docs
+BySpace
+ByRealSpace
+ByReciprocalSpace
+Base.inv(::Type{ByRealSpace})
+```
+
+## Coordinate traits
+```@docs
+ByCoordinate
+ByCartesianCoordinate
+ByFractionalCoordinate
+```

--- a/docs/src/lattices.md
+++ b/docs/src/lattices.md
@@ -5,16 +5,15 @@ types and functions for working with lattices of arbitrary dimension, not just t
 
 ## Real and reciprocal space traits
 
-The `Electrum.BySpace{D}` supertype contains two types, `Electrum.ByRealSpace{D}` and
-`Electrum.ByReciprocalSpace{D}`, where `D` is the number of dimensions associated with the dataset.
-These types are used to denote whether data is associated with real space (e.g. electron density) or 
-reciprocal space (e.g. the Fourier transform of the electron density). When working with lattices,
-it is important to distinguish the two types of lattice: this is the primary reason why bare
+The `BySpace` supertype contains two types, `ByRealSpace` and `ByReciprocalSpace`. These types are 
+used to denote whether data is associated with real space (e.g. electron density) or reciprocal 
+space (e.g. the Fourier transform of the electron density). When working with lattices, it is 
+important to distinguish the two types of lattice: this is the primary reason why bare
 `SMatrix{D,D,T}` instances are not used in this package.
 
 ## `Electrum.LatticeBasis` and methods
 
-The `Electrum.LatticeBasis{S<:Electrum.BySpace,D,T}` data type is a wrapper for an
+The `Electrum.LatticeBasis{S<:BySpace,D,T}` data type is a wrapper for an
 `SMatrix{D,D,T,D^2}` which represents the real or reciprocal space basis vectors of a lattice.
 
 Electrum does not export `Electrum.LatticeBasis`, but instead provide the following aliases. This
@@ -24,11 +23,6 @@ const RealBasis = Electrum.LatticeBasis{ByRealSpace}
 const ReciprocalBasis = Electrum.LatticeBasis{ByReciprocalSpace}
 const AbstractBasis = Electrum.LatticeBasis{<:BySpace}
 ```
-!!! warning
-    Note that `RealBasis{D} === Electrum.LatticeBasis{ByRealSpace,D}`, and not
-    `Electrum.LatticeBasis{ByRealSpace{D},D}`. While the latter is a valid type and can be used to
-    store data, the result of `Electrum.DataSpace(::Electrum.LatticeBasis{ByRealSpace{D},D})` is
-    an error!
 
 The units of `RealBasis` are bohr, and those of `ReciprocalBasis` are radians over bohr,
 corresponding with the convention that the dot product of a real basis vector with a corresponding
@@ -43,7 +37,7 @@ In the case of a `StaticMatrix`, the size and element type are already known, so
 can simply be called as `RealBasis` or `ReciprocalBasis`:
 ```
 julia> RealBasis(SMatrix{3,3}(1, 0, 0, 0, 2, 0, 0, 0, 3))
-Electrum.LatticeBasis{Electrum.ByRealSpace, 3, Int64}:
+Electrum.LatticeBasis{ByRealSpace, 3, Int64}:
     a: [  1.000000   0.000000   0.000000 ]   (1.000000 bohr)
     b: [  0.000000   2.000000   0.000000 ]   (2.000000 bohr)
     c: [  0.000000   0.000000   3.000000 ]   (3.000000 bohr)
@@ -53,7 +47,7 @@ should be supplied to avoid an exception being thrown. This is to avoid type ins
 from determining the size at runtime:
 ```
 julia> RealBasis{3}([1 0 0; 0 2 0; 0 0 3])
-Electrum.LatticeBasis{Electrum.ByRealSpace, 3, Int64}:
+Electrum.LatticeBasis{ByRealSpace, 3, Int64}:
     a: [  1.000000   0.000000   0.000000 ]   (1.000000 bohr)
     b: [  0.000000   2.000000   0.000000 ]   (2.000000 bohr)
     c: [  0.000000   0.000000   3.000000 ]   (3.000000 bohr)
@@ -62,15 +56,15 @@ In either case, you can supply the element type (though it must be proceeded by 
 cases) to convert the input elements to the desired type (here, it's `Float32`):
 ```
 julia> RealBasis{3,Float32}(SMatrix{3,3}(1, 0, 0, 0, 2, 0, 0, 0, 3))
-Electrum.LatticeBasis{Electrum.ByRealSpace, 3, Float32}:
+Electrum.LatticeBasis{ByRealSpace, 3, Float32}:
     a: [  1.000000   0.000000   0.000000 ]   (1.000000 bohr)
     b: [  0.000000   2.000000   0.000000 ]   (2.000000 bohr)
     c: [  0.000000   0.000000   3.000000 ]   (3.000000 bohr)
 ```
 ### Conversion
 
-A `RealBasis` can be converted to a `ReciprocalBasis` via `Base.convert` or their constructors,
-and vice versa:
+A `RealBasis` can be converted to a `ReciprocalBasis` via `convert` or their constructors, and vice
+versa:
 ```julia
 b = ReciprocalBasis(a)
 c = convert(RealBasis, b)

--- a/src/Electrum.jl
+++ b/src/Electrum.jl
@@ -110,6 +110,8 @@ include("math.jl")
 export FFTBins, FFTLength
 # Dispatch traits for data
 include("traits.jl")
+export BySpace, ByRealSpace, ByReciprocalSpace, ByCoordinate, ByCartesianCoordinate, 
+    ByFractionalCoordinate
 # Methods and structs for working with crystal lattices
 include("lattices.jl")
 export RealBasis, ReciprocalBasis, AbstractBasis

--- a/src/data/grids.jl
+++ b/src/data/grids.jl
@@ -48,6 +48,7 @@ struct DataGrid{D,B<:LatticeBasis,S<:AbstractVector{<:Real},T} <: AbstractArray{
 end
 
 Base.has_offset_axes(g::DataGrid) = true
+BySpace(::Type{T}) where T<:DataGrid = BySpace(fieldtype(T, :basis))
 
 Base.show(io::IO, g::DataGrid) = print(io, typeof(g), (g.data, g.basis, g.shift))
 
@@ -335,7 +336,7 @@ For reciprocal space data, the frequencies are binned with the assumption that t
 are given in angular wavenumbers, and they represent real space coordinates. The Nyquist frequency
 convention is *not* used, so all elements will have positive indices.
 """
-FFTW.fftfreq(g::DataGrid) = fftfreq(g, DataSpace(g))
+FFTW.fftfreq(g::DataGrid) = fftfreq(g, BySpace(g))
 
 #---Operations specific to `RealDataGrid`----------------------------------------------------------#
 """

--- a/src/data/spin.jl
+++ b/src/data/spin.jl
@@ -104,7 +104,7 @@ Base.getindex(b::SpinBivector, i::Int) = getindex(b.matrix, i)
 Base.getindex(b::SpinBivector, i::Int...) = getindex(b.matrix, i...)
 
 Base.:(==)(a::SpinBivector, b::SpinBivector) = (a.matrix == b.matrix)
-DataSpace(::Type{<:SpinBivector}) = ByRealSpace()
+BySpace(::Type{<:SpinBivector}) = ByRealSpace()
 # Required for StaticArray subtypes
 Base.Tuple(b::SpinBivector) = Tuple(b.matrix)
 

--- a/src/data/spin.jl
+++ b/src/data/spin.jl
@@ -104,7 +104,7 @@ Base.getindex(b::SpinBivector, i::Int) = getindex(b.matrix, i)
 Base.getindex(b::SpinBivector, i::Int...) = getindex(b.matrix, i...)
 
 Base.:(==)(a::SpinBivector, b::SpinBivector) = (a.matrix == b.matrix)
-DataSpace(::Type{<:SpinBivector{D}}) where D = ByRealSpace{D}()
+DataSpace(::Type{<:SpinBivector}) = ByRealSpace()
 # Required for StaticArray subtypes
 Base.Tuple(b::SpinBivector) = Tuple(b.matrix)
 

--- a/src/data/wavefunctions.jl
+++ b/src/data/wavefunctions.jl
@@ -154,6 +154,7 @@ struct PlanewaveWavefunction{D,T} <: AbstractArray{T,D}
 end
 
 Base.has_offset_axes(::PlanewaveWavefunction) = true
+BySpace(::Type{<:PlanewaveWavefunction}) = ByReciprocalSpace()
 
 """
     PlanewaveWavefunction{D,T}(

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -77,6 +77,8 @@ struct LatticeBasis{S<:BySpace,D,T<:Real} <: StaticMatrix{D,D,T}
     end
 end
 
+BySpace(::Type{<:LatticeBasis{S}}) where S = S()
+
 # Needed to resolve ambiguity with StaticArrays generic constructor
 LatticeBasis{S,D,T}(::StaticArray) where {S,D,T} = _nonsquare_matrix_error()
 LatticeBasis{S,D}(::StaticArray) where {S,D} = _nonsquare_matrix_error()
@@ -196,14 +198,6 @@ may store a reciprocal space lattice, allowing for properties of the data contai
 For predictable results, use `convert(T, basis(x))` where `T` is the desired type.
 """
 basis(x) = x.basis::LatticeBasis
-
-#---Real/reciprocal space traits-------------------------------------------------------------------#
-"""
-    Electrum.DataSpace(::Type{<:Electrum.LatticeBasis{S}}) = S()
-
-Returns the `ByRealSpace()` or `ByReciprocalSpace()` trait objects depending on the type of lattice.
-"""
-DataSpace(::Type{<:LatticeBasis{S}}) where S = S()
 
 #---Type promotion---------------------------------------------------------------------------------#
 

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -237,7 +237,7 @@ Base.inv(b::LatticeBasis) = inv(b.matrix)
 Returns the basis of the dual lattice, which is the lattice in dual space whose product with the
 original lattice is equal to the identity matrix multiplied by 2π.
 """
-dual(b::LatticeBasis{S}) where S = convert(LatticeBasis{inverse_space(S)}, b)
+dual(b::LatticeBasis{S}) where S = convert(LatticeBasis{inv(S)}, b)
 
 """
     dualbasis(x)

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -16,12 +16,12 @@ end
 _nonsquare_matrix_error() = throw(DimensionMismatch("Input must be a square matrix."))
 
 """
-    Electrum.LatticeBasis{S<:Electrum.BySpace,D,T} <: StaticMatrix{D,D,T}
+    Electrum.LatticeBasis{S<:BySpace,D,T} <: StaticMatrix{D,D,T}
 
 Represents the basis vectors of a `D`-dimensional lattice in real or reciprocal space, depending on
-`S`. The units of `LatticeBasis{Electrum.ByRealSpace}` are bohr, and those of
-`LatticeBasis{Electrum.ByReciprocalSpace}` are rad*bohr⁻¹, corresponding to the convention that the
-dot product of a real space basis vector with a reciprocal space basis vector is 2π.
+`S`. The units of `LatticeBasis{ByRealSpace}` are bohr, and those of
+`LatticeBasis{ByReciprocalSpace}` are rad*bohr⁻¹, corresponding to the convention that the dot
+product of a real space basis vector with a reciprocal space basis vector is 2π.
 
 # Type aliases
 
@@ -86,7 +86,7 @@ LatticeBasis{S,D}(::StaticArray) where {S,D} = _nonsquare_matrix_error()
 Base.show(io::IO, b::LatticeBasis) = print(io, typeof(b), '(', b.matrix, ')')
 
 """
-    RealBasis{D,T} (alias for Electrum.LatticeBasis{Electrum.ByRealSpace,D,T})
+    RealBasis{D,T} (alias for Electrum.LatticeBasis{ByRealSpace,D,T})
 
 Represents a the basis vectors of a lattice in real space, with lengths given in units of bohr.
 
@@ -95,7 +95,7 @@ For more information about this type, see [`Electrum.LatticeBasis`](@ref Electru
 const RealBasis = LatticeBasis{ByRealSpace}
 
 """
-    ReciprocalBasis{D,T} (alias for Electrum.LatticeBasis{Electrum.ByReciprocalSpace,D,T})
+    ReciprocalBasis{D,T} (alias for Electrum.LatticeBasis{ByReciprocalSpace,D,T})
 
 Represents a the basis vectors of a lattice in reciprocal space, with lengths given in units of 
 radians per bohr.

--- a/src/lattices.jl
+++ b/src/lattices.jl
@@ -84,7 +84,7 @@ LatticeBasis{S,D}(::StaticArray) where {S,D} = _nonsquare_matrix_error()
 Base.show(io::IO, b::LatticeBasis) = print(io, typeof(b), '(', b.matrix, ')')
 
 """
-    RealBasis{D,T} (alias for Electrum.LatticeBasis{ByRealSpace,D,T})
+    RealBasis{D,T} (alias for Electrum.LatticeBasis{Electrum.ByRealSpace,D,T})
 
 Represents a the basis vectors of a lattice in real space, with lengths given in units of bohr.
 
@@ -93,7 +93,7 @@ For more information about this type, see [`Electrum.LatticeBasis`](@ref Electru
 const RealBasis = LatticeBasis{ByRealSpace}
 
 """
-    ReciprocalBasis{D,T} (alias for Electrum.LatticeBasis{ByRealSpace,D,T})
+    ReciprocalBasis{D,T} (alias for Electrum.LatticeBasis{Electrum.ByReciprocalSpace,D,T})
 
 Represents a the basis vectors of a lattice in reciprocal space, with lengths given in units of 
 radians per bohr.
@@ -103,7 +103,7 @@ For more information about this type, see [`Electrum.LatticeBasis`](@ref Electru
 const ReciprocalBasis = LatticeBasis{ByReciprocalSpace}
 
 """
-    AbstractBasis{D,T} (alias for Electrum.LatticeBasis{BySpace,D,T})
+    AbstractBasis{D,T} (alias for Electrum.LatticeBasis{<:BySpace,D,T})
 
 Supertype that contains `RealBasis{D,T}` and `ReciprocalBasis{D,T}`. Code that can dispatch on
 either `RealBasis` or `ReciprocalBasis` can refer to this type.
@@ -199,20 +199,11 @@ basis(x) = x.basis::LatticeBasis
 
 #---Real/reciprocal space traits-------------------------------------------------------------------#
 """
-    Electrum.DataSpace(::Type{<:Electrum.LatticeBasis{S,D}}) = S{D}()
+    Electrum.DataSpace(::Type{<:Electrum.LatticeBasis{S}}) = S()
 
-Returns the `ByRealSpace{D}()` or `ByReciprocalSpace{D}()` trait objects depending on the type of
-lattice.
-
-Note that this function only works correctly when S === `ByRealSpace` or `ByReciprocalSpace`, and
-not if they are `ByRealSpace{D}` or `ByReciprocalSpace{D}`, or their singleton instances. Even
-though `Electrum.LatticeBasis{ByRealSpace{D},D,T}` is a valid type that has otherwise correct
-behavior, this function only works correctly when for `Electrum.LatticeBasis{ByRealSpace,D}` and
-`Electrum.LatticeBasis{ByReciprocalSpace,D}`, which are aliased by `RealBasis{D}` and
-`ReciprocalBasis{D}` respectively.
-``
+Returns the `ByRealSpace()` or `ByReciprocalSpace()` trait objects depending on the type of lattice.
 """
-DataSpace(::Type{<:LatticeBasis{S,D}}) where {S,D} = S{D}()
+DataSpace(::Type{<:LatticeBasis{S}}) where S = S()
 
 #---Type promotion---------------------------------------------------------------------------------#
 

--- a/src/software/toml.jl
+++ b/src/software/toml.jl
@@ -7,8 +7,8 @@ function toml_convert end
 
 function toml_convert(b::AbstractBasis)
     return Dict{String,Any}(
-        "realspace" => !(DataSpace(b) isa ByReciprocalSpace),
-        "dimension" => size(b,1),
+        "realspace" => !(BySpace(b) === ByReciprocalSpace()),
+        "dimension" => size(b, 1),
         "vectors" => b.vectors
     )
 end

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -100,6 +100,31 @@ method for type instances is defined automatically.
 BySpace(::Type) = error("No BySpace trait is associated with this type.")
 BySpace(x) = BySpace(typeof(x))
 
+"""
+    Electrum.require_same_space(args...; msg)
+
+Checks that the `BySpace` traits of all arguments are identical, throwing an error with optional
+message `msg` if this is not the case.
+"""
+function require_same_space(
+    traits::Tuple{Vararg{BySpace}};
+    msg = "Inputs must describe the same space (real or reciprocal)."
+)
+    traits isa NTuple || error(msg)
+end
+
+require_same_space(args...; msg) = require_same_coordinate(BySpace.(args); msg)
+
+"""
+    Electrum.require_same_space(a, b; msg)
+
+Checks that the `BySpace` trait of `a` is the inverse of the `BySpace` trait of `b`,  throwing an
+error with optional message `msg` if this is not the case.
+"""
+function require_dual_space(a, b; msg = "One input must describe the inverse space of the other.")
+    BySpace(a) === inv(BySpace(b)) || error(msg)
+end
+
 #---Coordinate type--------------------------------------------------------------------------------#
 """
     ByCoordinate <: Electrum.CrystalDataTrait
@@ -140,3 +165,18 @@ for a custom type `T`, define `ByCoordinate(::Type{T}) where T`.
 """
 ByCoordinate(x) = ByCoordinate(typeof(x))
 ByCoordinate(::Type) = error("No coordinate trait is defined for this type.")
+
+"""
+    Electrum.require_same_space(args...; msg)
+
+Checks that the `ByCoordinate` traits of all arguments are identical, throwing an error with 
+optional message `msg` if this is not the case.
+"""
+function require_same_coordinate(
+    traits::Tuple{Vararg{ByCoordinate}};
+    msg = "Inputs must share a common coordinate system."
+)
+    traits isa NTuple || error(msg)
+end
+
+require_same_coordinate(args...; msg) = require_same_coordinate(ByCoordinate.(args); msg)

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -68,6 +68,7 @@ Base.inv(::Type{ByRealSpace}) = ByReciprocalSpace
 Base.inv(::Type{ByReciprocalSpace}) = ByRealSpace
 Base.inv(::T) where T<:BySpace = inv(T)()
 
+#= TODO: resurrect this function at some point
 """
     Electrum.DataSpace(x) -> Electrum.DataSpace
 
@@ -86,6 +87,7 @@ are `Electrum.LatticeBasis` objects stored in the `basis` field, it will be nece
 """
 DataSpace(x) = DataSpace(typeof(x))
 DataSpace(T::Type) = DataSpace(fieldtype(T, :basis))
+=#
 
 """
     BySpace(T::Type) -> BySpace

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -1,6 +1,6 @@
 #---Trait supertype--------------------------------------------------------------------------------#
 """
-    CrystalDataTrait
+    Electrum.CrystalDataTrait
 
 Subtypes of this type are traits that may be used for dispatch.
 """
@@ -9,7 +9,7 @@ end
 
 #---Association of data with spatial coordinates---------------------------------------------------#
 """
-    DataSpace <: CrystalDataTrait
+    Electrum.DataSpace <: Electrum.CrystalDataTrait
 
 Describes the space in which a dataset is defined, which can be real space, reciprocal space, or
 data associated with individual atoms in a structure.
@@ -18,15 +18,15 @@ abstract type DataSpace <: CrystalDataTrait
 end
 
 """
-    ByAtom
+    Electrum.ByAtom <: Electrum.DataSpace
 
-Trait for data associated with atomic positions in a crystal.
+Trait for data associated with atoms in a crystal.
 """
 struct ByAtom <: DataSpace
 end
 
 """
-    BySpace
+    BySpace <: Electrum.DataSpace
 
 Supertype for the `ByRealSpace` and `ByReciprocalSpace` traits.
 """
@@ -34,7 +34,7 @@ abstract type BySpace <: DataSpace
 end
 
 """
-    ByRealSpace
+    ByRealSpace <: BySpace
 
 Trait for real space data.
 """
@@ -42,7 +42,7 @@ struct ByRealSpace <: BySpace
 end
 
 """
-    ByReciprocalSpace
+    ByReciprocalSpace <: BySpace
 
 Trait for reciprocal space data.
 """
@@ -57,11 +57,11 @@ Returns the space trait dual to the given space trait. Either a type or an insta
 
 # Examples
 ```julia-repl
-julia> inv(Electrum.ByReciprocalSpace)
-Electrum.ByRealSpace
+julia> inv(ByReciprocalSpace)
+ByRealSpace
 
-julia> inv(Electrum.ByRealSpace())
-Electrum.ByReciprocalSpace()
+julia> inv(ByRealSpace())
+ByReciprocalSpace()
 ```
 """
 Base.inv(::Type{ByRealSpace}) = ByReciprocalSpace
@@ -69,7 +69,7 @@ Base.inv(::Type{ByReciprocalSpace}) = ByRealSpace
 Base.inv(::T) where T<:BySpace = inv(T)()
 
 """
-    Electrum.DataSpace(x) -> DataSpace
+    Electrum.DataSpace(x) -> Electrum.DataSpace
 
 Returns a trait that determines whether a data set associated with a crystal is defined in real
 space (`ByRealSpace`), reciprocal space (`ByReciprocalSpace`), or by atomic positions (`ByAtom`).
@@ -102,7 +102,7 @@ BySpace(x) = BySpace(typeof(x))
 
 #---Coordinate type--------------------------------------------------------------------------------#
 """
-    ByCoordinate <: CrystalDataTrait
+    ByCoordinate <: Electrum.CrystalDataTrait
 
 Describes the coordinate system associated with data. This includes `ByCartesianCoordinate` and
 `ByFractionalCoordinate`.

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -112,10 +112,10 @@ function require_same_space(
     traits::Tuple{Vararg{BySpace}};
     msg = "Inputs must describe the same space (real or reciprocal)."
 )
-    traits isa NTuple || error(msg)
+    return traits isa NTuple ? nothing : error(msg)
 end
 
-require_same_space(args...; msg) = require_same_coordinate(BySpace.(args); msg)
+require_same_space(args...; msg...) = require_same_space(BySpace.(args); msg...)
 
 """
     Electrum.require_same_space(a, b; msg)
@@ -124,7 +124,7 @@ Checks that the `BySpace` trait of `a` is the inverse of the `BySpace` trait of 
 error with optional message `msg` if this is not the case.
 """
 function require_dual_space(a, b; msg = "One input must describe the inverse space of the other.")
-    BySpace(a) === inv(BySpace(b)) || error(msg)
+    return BySpace(a) === inv(BySpace(b)) ? nothing : error(msg)
 end
 
 #---Coordinate type--------------------------------------------------------------------------------#
@@ -178,7 +178,7 @@ function require_same_coordinate(
     traits::Tuple{Vararg{ByCoordinate}};
     msg = "Inputs must share a common coordinate system."
 )
-    traits isa NTuple || error(msg)
+    return traits isa NTuple ? nothing : error(msg)
 end
 
-require_same_coordinate(args...; msg) = require_same_coordinate(ByCoordinate.(args); msg)
+require_same_coordinate(args...; msg...) = require_same_coordinate(ByCoordinate.(args); msg...)

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -50,23 +50,23 @@ struct ByReciprocalSpace <: BySpace
 end
 
 """
-    Electrum.inverse_space(::Type{<:BySpace}) -> Type{<:BySpace}
-    Electrum.inverse_space(::BySpace) -> BySpace
+    inv(::Type{<:BySpace}) -> Type{<:BySpace}
+    inv(::BySpace) -> BySpace
 
 Returns the space trait dual to the given space trait. Either a type or an instance may be given.
 
 # Examples
 ```julia-repl
-julia> Electrum.inverse_space(Electrum.ByReciprocalSpace)
+julia> inv(Electrum.ByReciprocalSpace)
 Electrum.ByRealSpace
 
-julia> Electrum.inverse_space(Electrum.ByRealSpace())
+julia> inv(Electrum.ByRealSpace())
 Electrum.ByReciprocalSpace()
 ```
 """
-inverse_space(::Type{ByRealSpace}) = ByReciprocalSpace
-inverse_space(::Type{ByReciprocalSpace}) = ByRealSpace
-inverse_space(::T) where T<:BySpace = inverse_space(T)()
+Base.inv(::Type{ByRealSpace}) = ByReciprocalSpace
+Base.inv(::Type{ByReciprocalSpace}) = ByRealSpace
+Base.inv(::T) where T<:BySpace = inv(T)()
 
 """
     Electrum.DataSpace(x) -> DataSpace

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -87,6 +87,19 @@ are `Electrum.LatticeBasis` objects stored in the `basis` field, it will be nece
 DataSpace(x) = DataSpace(typeof(x))
 DataSpace(T::Type) = DataSpace(fieldtype(T, :basis))
 
+"""
+    BySpace(T::Type) -> BySpace
+    BySpace(x) -> BySpace
+
+Returns a trait object that describes whether data is associated with real space
+([`ByRealSpace`](@ref)) or reciprocal space ([`ByReciprocalSpace`](@ref)).
+
+New types `T` should implement the `BySpace` trait by implementing `BySpace(::Type{T})`, as the
+method for type instances is defined automatically.
+"""
+BySpace(::Type) = error("No BySpace trait is associated with this type.")
+BySpace(x) = BySpace(typeof(x))
+
 #---Coordinate type--------------------------------------------------------------------------------#
 """
     ByCoordinate <: CrystalDataTrait

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -9,44 +9,44 @@ end
 
 #---Association of data with spatial coordinates---------------------------------------------------#
 """
-    DataSpace{D} <: CrystalDataTrait
+    DataSpace <: CrystalDataTrait
 
 Describes the space in which a dataset is defined, which can be real space, reciprocal space, or
 data associated with individual atoms in a structure.
 """
-abstract type DataSpace{D} <: CrystalDataTrait
+abstract type DataSpace <: CrystalDataTrait
 end
 
 """
-    ByAtom{D}
+    ByAtom
 
 Trait for data associated with atomic positions in a crystal.
 """
-struct ByAtom{D} <: DataSpace{D}
+struct ByAtom <: DataSpace
 end
 
 """
-    BySpace{D}
+    BySpace
 
-Supertype for the `ByRealSpace{D}` and `ByReciprocalSpace{D}` traits.
+Supertype for the `ByRealSpace` and `ByReciprocalSpace` traits.
 """
-abstract type BySpace{D} <: DataSpace{D}
+abstract type BySpace <: DataSpace
 end
 
 """
-    ByRealSpace{D}
+    ByRealSpace
 
-Trait for real space data in `D` dimensions.
+Trait for real space data.
 """
-struct ByRealSpace{D} <: BySpace{D}
+struct ByRealSpace <: BySpace
 end
 
 """
-    ByReciprocalSpace{D}
+    ByReciprocalSpace
 
-Trait for reciprocal space data in `D` dimensions.
+Trait for reciprocal space data.
 """
-struct ByReciprocalSpace{D} <: BySpace{D}
+struct ByReciprocalSpace <: BySpace
 end
 
 """
@@ -60,25 +60,19 @@ Returns the space trait dual to the given space trait. Either a type or an insta
 julia> Electrum.inverse_space(Electrum.ByReciprocalSpace)
 Electrum.ByRealSpace
 
-julia> Electrum.inverse_space(Electrum.ByRealSpace{3})
-Electrum.ByReciprocalSpace{3}
-
-julia> Electrum.inverse_space(Electrum.ByRealSpace{3}())
-Electrum.ByReciprocalSpace{3}()
+julia> Electrum.inverse_space(Electrum.ByRealSpace())
+Electrum.ByReciprocalSpace()
 ```
 """
 inverse_space(::Type{ByRealSpace}) = ByReciprocalSpace
 inverse_space(::Type{ByReciprocalSpace}) = ByRealSpace
-inverse_space(::Type{ByRealSpace{D}}) where D = ByReciprocalSpace{D}
-inverse_space(::Type{ByReciprocalSpace{D}}) where D = ByRealSpace{D}
 inverse_space(::T) where T<:BySpace = inverse_space(T)()
 
 """
     Electrum.DataSpace(x) -> DataSpace
 
 Returns a trait that determines whether a data set associated with a crystal is defined in real
-space (`ByRealSpace{D}()`), reciprocal space (`ByReciprocalSpace{D}()`), or by atomic positions
-(`ByAtom{D}`), where `D` is the number of dimensions.
+space (`ByRealSpace`), reciprocal space (`ByReciprocalSpace`), or by atomic positions (`ByAtom`).
 
 By default, `DataSpace(x)` will infer the appropriate trait from the lattice basis vectors
 included in `x`, assumed to be in a field named `basis`. The fallback definition is:
@@ -93,49 +87,32 @@ are `Electrum.LatticeBasis` objects stored in the `basis` field, it will be nece
 DataSpace(x) = DataSpace(typeof(x))
 DataSpace(T::Type) = DataSpace(fieldtype(T, :basis))
 
-"""
-    Electrum.dimension(::DataSpace{D}) = D
-    Electrum.dimension(::Type{<:DataSpace{D}}) = D
-
-Returns the number of dimensions (or other object representing the dimensionality) associated with a
-`DataSpace` trait.
-"""
-dimension(::DataSpace{D}) where D = D
-dimension(::Type{<:DataSpace{D}}) where D = D
-
-"""
-    Electrum.dimension(x)
-
-Infers the number of dimensions `Electrum.DataSpace(x)` from the result of `DataSpace(x)`.
-"""
-dimension(x) = dimension(DataSpace(x))
-
 #---Coordinate type--------------------------------------------------------------------------------#
 """
-    ByCoordinate{D} <: CrystalDataTrait
+    ByCoordinate <: CrystalDataTrait
 
-Describes the coordinate system associated with data. This includes `ByCartesianCoordinate{D}` and
-`ByFractionalCoordinate{D}`.
+Describes the coordinate system associated with data. This includes `ByCartesianCoordinate` and
+`ByFractionalCoordinate`.
 """
-abstract type ByCoordinate{D} <: CrystalDataTrait
+abstract type ByCoordinate <: CrystalDataTrait
 end
 
 """
-    ByCartesianCoordinate{D} <: ByCoordinate{D}
+    ByCartesianCoordinate <: ByCoordinate
 
-Trait type for coordinates in `D` dimensions represented in terms of an implicit orthonormal basis
-in units of bohr or rad*bohr⁻¹.
+Trait type for coordinates represented in terms of an implicit orthonormal basis with units of bohr
+or rad*bohr⁻¹.
 """
-struct ByCartesianCoordinate{D} <: ByCoordinate{D}
+struct ByCartesianCoordinate <: ByCoordinate
 end
 
 """
-    ByFractionalCoordinate{D} <: ByCoordinate{D}
+    ByFractionalCoordinate <: ByCoordinate
 
 Trait type for coordinates in `D` dimensions whose values depend on a choice of basis, usually the
 basis vectors describing the lattice in which the coordinate is contained.
 """
-struct ByFractionalCoordinate{D} <: ByCoordinate{D}
+struct ByFractionalCoordinate <: ByCoordinate
 end
 
 """

--- a/src/vectors.jl
+++ b/src/vectors.jl
@@ -90,8 +90,8 @@ Moves a `ShiftVector` so that its values lie within the range [-1/2, 1/2]. The w
 """
 Base.truncate(s::ShiftVector) = (typeof(s))(rem.(s.vector, 1, RoundNearest), s.weight)
 
-DataSpace(::Type{<:ShiftVector{S,D}}) where {S,D} = S{D}()
-ByCoordinate(::Type{<:ShiftVector{S,D}}) where {S,D} = ByFractionalCoordinate{D}()
+DataSpace(::Type{<:ShiftVector{S,D}}) where {S,D} = S()
+ByCoordinate(::Type{<:ShiftVector{S,D}}) where {S,D} = ByFractionalCoordinate()
 
 Base.summary(io::IO, s::ShiftVector) = print(io, typeof(s), " with weight ", s.weight)
 Base.show(io::IO, s::ShiftVector) = print(io, typeof(s), '(', s.vector, ", ", s.weight, ')')

--- a/src/vectors.jl
+++ b/src/vectors.jl
@@ -90,7 +90,7 @@ Moves a `ShiftVector` so that its values lie within the range [-1/2, 1/2]. The w
 """
 Base.truncate(s::ShiftVector) = (typeof(s))(rem.(s.vector, 1, RoundNearest), s.weight)
 
-DataSpace(::Type{<:ShiftVector{S,D}}) where {S,D} = S()
+BySpace(::Type{<:ShiftVector{S,D}}) where {S,D} = S()
 ByCoordinate(::Type{<:ShiftVector{S,D}}) where {S,D} = ByFractionalCoordinate()
 
 Base.summary(io::IO, s::ShiftVector) = print(io, typeof(s), " with weight ", s.weight)

--- a/test/internals.jl
+++ b/test/internals.jl
@@ -33,8 +33,8 @@
     @test Electrum.BySpace(basis(wavecar)) === Electrum.ByReciprocalSpace()
     @test Electrum.BySpace(wavecar) === Electrum.ByReciprocalSpace()
     @test Electrum.BySpace(typeof(wavecar)) === Electrum.ByReciprocalSpace()
-    @test Electrum.inverse_space(Electrum.ByRealSpace) === Electrum.ByReciprocalSpace
-    @test Electrum.inverse_space(Electrum.ByReciprocalSpace) === Electrum.ByRealSpace
-    @test Electrum.inverse_space(Electrum.ByRealSpace()) === Electrum.ByReciprocalSpace()
-    @test Electrum.inverse_space(Electrum.ByReciprocalSpace()) === Electrum.ByRealSpace()
+    @test inv(Electrum.ByRealSpace) === Electrum.ByReciprocalSpace
+    @test inv(Electrum.ByReciprocalSpace) === Electrum.ByRealSpace
+    @test inv(Electrum.ByRealSpace()) === Electrum.ByReciprocalSpace()
+    @test inv(Electrum.ByReciprocalSpace()) === Electrum.ByRealSpace()
 end

--- a/test/internals.jl
+++ b/test/internals.jl
@@ -12,8 +12,8 @@
     # Arguments not convertible to integers should fail
     @test_throws InexactError convert_to_transform(1.5, 2)
     # Data space traits
-    @test Electrum.BySpace(xsf["this_is_3Dgrid#1"]) === Electrum.ByRealSpace()
-    @test Electrum.BySpace(v80_wfk["wavefunction"]) === Electrum.ByReciprocalSpace()
+    @test BySpace(xsf["this_is_3Dgrid#1"]) === ByRealSpace()
+    @test BySpace(v80_wfk["wavefunction"]) === ByReciprocalSpace()
     # Offset axes
     @test Base.has_offset_axes(xsf["this_is_3Dgrid#1"])
     @test Base.has_offset_axes(v80_wfk["wavefunction"])
@@ -29,12 +29,12 @@
     @test Electrum.SUnitVector{3}(1)[1:2] == [1, 0]
     @test_throws MethodError Electrum.SUnitVector{3,Char}(1)
     # Traits
-    @test Electrum.BySpace(RealBasis{3}) === Electrum.ByRealSpace()
-    @test Electrum.BySpace(basis(wavecar)) === Electrum.ByReciprocalSpace()
-    @test Electrum.BySpace(wavecar) === Electrum.ByReciprocalSpace()
-    @test Electrum.BySpace(typeof(wavecar)) === Electrum.ByReciprocalSpace()
-    @test inv(Electrum.ByRealSpace) === Electrum.ByReciprocalSpace
-    @test inv(Electrum.ByReciprocalSpace) === Electrum.ByRealSpace
-    @test inv(Electrum.ByRealSpace()) === Electrum.ByReciprocalSpace()
-    @test inv(Electrum.ByReciprocalSpace()) === Electrum.ByRealSpace()
+    @test BySpace(RealBasis{3}) === ByRealSpace()
+    @test BySpace(basis(wavecar)) === ByReciprocalSpace()
+    @test BySpace(wavecar) === ByReciprocalSpace()
+    @test BySpace(typeof(wavecar)) === ByReciprocalSpace()
+    @test inv(ByRealSpace) === ByReciprocalSpace
+    @test inv(ByReciprocalSpace) === ByRealSpace
+    @test inv(ByRealSpace()) === ByReciprocalSpace()
+    @test inv(ByReciprocalSpace()) === ByRealSpace()
 end

--- a/test/internals.jl
+++ b/test/internals.jl
@@ -28,13 +28,27 @@
     @test Electrum.SUnitVector{3}(1)[:] === SVector{3,Bool}(1, 0, 0)
     @test Electrum.SUnitVector{3}(1)[1:2] == [1, 0]
     @test_throws MethodError Electrum.SUnitVector{3,Char}(1)
-    # Traits
+    # BySpace traits
     @test BySpace(RealBasis{3}) === ByRealSpace()
     @test BySpace(basis(wavecar)) === ByReciprocalSpace()
     @test BySpace(wavecar) === ByReciprocalSpace()
     @test BySpace(typeof(wavecar)) === ByReciprocalSpace()
+    @test_throws Exception BySpace(420)
+    @test_throws Exception BySpace(Int)
     @test inv(ByRealSpace) === ByReciprocalSpace
     @test inv(ByReciprocalSpace) === ByRealSpace
     @test inv(ByRealSpace()) === ByReciprocalSpace()
     @test inv(ByReciprocalSpace()) === ByRealSpace()
+    # ByCoordinate traits
+    @test ByCoordinate(KPoint(0, 0, 0)) === ByFractionalCoordinate()
+    @test ByCoordinate(KPoint{3,Int}) === ByFractionalCoordinate()
+    @test_throws Exception ByCoordinate(420)
+    @test_throws Exception ByCoordinate(Int)
+    # Requirements for compatible traits
+    (k1, k2, s) = (KPoint(0, 0, 0), KPoint(1/2, 1/2, 1/2), zero(ShiftVector{ByRealSpace,3}))
+    @test isnothing(Electrum.require_same_space(k1, k2))
+    @test isnothing(Electrum.require_dual_space(k1, s))
+    @test isnothing(Electrum.require_same_coordinate(k1, k2))
+    @test_throws Exception Electrum.require_same_space(k1, s)
+    @test_throws Exception Electrum.require_dual_space(k1, k2)
 end

--- a/test/internals.jl
+++ b/test/internals.jl
@@ -12,8 +12,8 @@
     # Arguments not convertible to integers should fail
     @test_throws InexactError convert_to_transform(1.5, 2)
     # Data space traits
-    @test Electrum.DataSpace(xsf["this_is_3Dgrid#1"]) === Electrum.ByRealSpace{3}()
-    @test Electrum.DataSpace(v80_wfk["wavefunction"]) === Electrum.ByReciprocalSpace{3}()
+    @test Electrum.DataSpace(xsf["this_is_3Dgrid#1"]) === Electrum.ByRealSpace()
+    @test Electrum.DataSpace(v80_wfk["wavefunction"]) === Electrum.ByReciprocalSpace()
     # Offset axes
     @test Base.has_offset_axes(xsf["this_is_3Dgrid#1"])
     @test Base.has_offset_axes(v80_wfk["wavefunction"])
@@ -29,17 +29,12 @@
     @test Electrum.SUnitVector{3}(1)[1:2] == [1, 0]
     @test_throws MethodError Electrum.SUnitVector{3,Char}(1)
     # Traits
-    @test Electrum.DataSpace(RealBasis{3}) === Electrum.ByRealSpace{3}()
-    @test Electrum.DataSpace(basis(wavecar)) === Electrum.ByReciprocalSpace{3}()
-    @test Electrum.DataSpace(wavecar) === Electrum.ByReciprocalSpace{3}()
-    @test Electrum.DataSpace(typeof(wavecar)) === Electrum.ByReciprocalSpace{3}()
+    @test Electrum.DataSpace(RealBasis{3}) === Electrum.ByRealSpace()
+    @test Electrum.DataSpace(basis(wavecar)) === Electrum.ByReciprocalSpace()
+    @test Electrum.DataSpace(wavecar) === Electrum.ByReciprocalSpace()
+    @test Electrum.DataSpace(typeof(wavecar)) === Electrum.ByReciprocalSpace()
     @test Electrum.inverse_space(Electrum.ByRealSpace) === Electrum.ByReciprocalSpace
     @test Electrum.inverse_space(Electrum.ByReciprocalSpace) === Electrum.ByRealSpace
-    @test Electrum.inverse_space(Electrum.ByRealSpace{3}) === Electrum.ByReciprocalSpace{3}
-    @test Electrum.inverse_space(Electrum.ByReciprocalSpace{3}) === Electrum.ByRealSpace{3}
-    @test Electrum.inverse_space(Electrum.ByRealSpace{3}()) === Electrum.ByReciprocalSpace{3}()
-    @test Electrum.inverse_space(Electrum.ByReciprocalSpace{3}()) === Electrum.ByRealSpace{3}()
-    @test Electrum.dimension(wavecar) === 3
-    @test Electrum.dimension(basis(wavecar)) === 3
-    @test Electrum.dimension(typeof(wavecar)) === 3
+    @test Electrum.inverse_space(Electrum.ByRealSpace()) === Electrum.ByReciprocalSpace()
+    @test Electrum.inverse_space(Electrum.ByReciprocalSpace()) === Electrum.ByRealSpace()
 end

--- a/test/internals.jl
+++ b/test/internals.jl
@@ -12,8 +12,8 @@
     # Arguments not convertible to integers should fail
     @test_throws InexactError convert_to_transform(1.5, 2)
     # Data space traits
-    @test Electrum.DataSpace(xsf["this_is_3Dgrid#1"]) === Electrum.ByRealSpace()
-    @test Electrum.DataSpace(v80_wfk["wavefunction"]) === Electrum.ByReciprocalSpace()
+    @test Electrum.BySpace(xsf["this_is_3Dgrid#1"]) === Electrum.ByRealSpace()
+    @test Electrum.BySpace(v80_wfk["wavefunction"]) === Electrum.ByReciprocalSpace()
     # Offset axes
     @test Base.has_offset_axes(xsf["this_is_3Dgrid#1"])
     @test Base.has_offset_axes(v80_wfk["wavefunction"])
@@ -29,10 +29,10 @@
     @test Electrum.SUnitVector{3}(1)[1:2] == [1, 0]
     @test_throws MethodError Electrum.SUnitVector{3,Char}(1)
     # Traits
-    @test Electrum.DataSpace(RealBasis{3}) === Electrum.ByRealSpace()
-    @test Electrum.DataSpace(basis(wavecar)) === Electrum.ByReciprocalSpace()
-    @test Electrum.DataSpace(wavecar) === Electrum.ByReciprocalSpace()
-    @test Electrum.DataSpace(typeof(wavecar)) === Electrum.ByReciprocalSpace()
+    @test Electrum.BySpace(RealBasis{3}) === Electrum.ByRealSpace()
+    @test Electrum.BySpace(basis(wavecar)) === Electrum.ByReciprocalSpace()
+    @test Electrum.BySpace(wavecar) === Electrum.ByReciprocalSpace()
+    @test Electrum.BySpace(typeof(wavecar)) === Electrum.ByReciprocalSpace()
     @test Electrum.inverse_space(Electrum.ByRealSpace) === Electrum.ByReciprocalSpace
     @test Electrum.inverse_space(Electrum.ByReciprocalSpace) === Electrum.ByRealSpace
     @test Electrum.inverse_space(Electrum.ByRealSpace()) === Electrum.ByReciprocalSpace()

--- a/test/kpoints.jl
+++ b/test/kpoints.jl
@@ -19,8 +19,8 @@
     @test_throws Exception KPoint{3}(SMatrix{3,1}([0, 0, 0]))
     @test_throws Exception KPoint{3,Int}(SMatrix{3,1}([0, 0, 0]))
     # Traits
-    @test Electrum.DataSpace(zero(KPoint{3})) === Electrum.ByReciprocalSpace{3}()
-    @test Electrum.ByCoordinate(zero(KPoint{3})) === Electrum.ByFractionalCoordinate{3}()
+    @test Electrum.DataSpace(zero(KPoint{3})) === Electrum.ByReciprocalSpace()
+    @test Electrum.ByCoordinate(zero(KPoint{3})) === Electrum.ByFractionalCoordinate()
     # Truncation
     # TODO: see note for trunc() in src/vectors.jl
     @test truncate(KPoint(1, 2, 3)) == KPoint(0, 0, 0)

--- a/test/kpoints.jl
+++ b/test/kpoints.jl
@@ -19,8 +19,8 @@
     @test_throws Exception KPoint{3}(SMatrix{3,1}([0, 0, 0]))
     @test_throws Exception KPoint{3,Int}(SMatrix{3,1}([0, 0, 0]))
     # Traits
-    @test Electrum.BySpace(zero(KPoint{3})) === Electrum.ByReciprocalSpace()
-    @test Electrum.ByCoordinate(zero(KPoint{3})) === Electrum.ByFractionalCoordinate()
+    @test BySpace(zero(KPoint{3})) === ByReciprocalSpace()
+    @test ByCoordinate(zero(KPoint{3})) === ByFractionalCoordinate()
     # Truncation
     # TODO: see note for trunc() in src/vectors.jl
     @test truncate(KPoint(1, 2, 3)) == KPoint(0, 0, 0)

--- a/test/kpoints.jl
+++ b/test/kpoints.jl
@@ -19,7 +19,7 @@
     @test_throws Exception KPoint{3}(SMatrix{3,1}([0, 0, 0]))
     @test_throws Exception KPoint{3,Int}(SMatrix{3,1}([0, 0, 0]))
     # Traits
-    @test Electrum.DataSpace(zero(KPoint{3})) === Electrum.ByReciprocalSpace()
+    @test Electrum.BySpace(zero(KPoint{3})) === Electrum.ByReciprocalSpace()
     @test Electrum.ByCoordinate(zero(KPoint{3})) === Electrum.ByFractionalCoordinate()
     # Truncation
     # TODO: see note for trunc() in src/vectors.jl

--- a/test/spin.jl
+++ b/test/spin.jl
@@ -58,6 +58,6 @@ end
     @test_throws DimensionMismatch SpinBivector(SVector{2}(1, 0), SVector{3}(0, 1, 0))
     @test_throws DimensionMismatch SpinBivector{3}([1, 0, 0], [0, 1])
     # Traits
-    @test Electrum.BySpace(SpinBivector{3}) === Electrum.ByRealSpace()
-    @test Electrum.BySpace(s_z) === Electrum.ByRealSpace()
+    @test BySpace(SpinBivector{3}) === ByRealSpace()
+    @test BySpace(s_z) === ByRealSpace()
 end

--- a/test/spin.jl
+++ b/test/spin.jl
@@ -58,6 +58,6 @@ end
     @test_throws DimensionMismatch SpinBivector(SVector{2}(1, 0), SVector{3}(0, 1, 0))
     @test_throws DimensionMismatch SpinBivector{3}([1, 0, 0], [0, 1])
     # Traits
-    @test Electrum.DataSpace(SpinBivector{3}) === Electrum.ByRealSpace()
-    @test Electrum.DataSpace(s_z) === Electrum.ByRealSpace()
+    @test Electrum.BySpace(SpinBivector{3}) === Electrum.ByRealSpace()
+    @test Electrum.BySpace(s_z) === Electrum.ByRealSpace()
 end

--- a/test/spin.jl
+++ b/test/spin.jl
@@ -58,6 +58,6 @@ end
     @test_throws DimensionMismatch SpinBivector(SVector{2}(1, 0), SVector{3}(0, 1, 0))
     @test_throws DimensionMismatch SpinBivector{3}([1, 0, 0], [0, 1])
     # Traits
-    @test Electrum.DataSpace(SpinBivector{3}) === Electrum.ByRealSpace{3}()
-    @test Electrum.DataSpace(s_z) === Electrum.ByRealSpace{3}()
+    @test Electrum.DataSpace(SpinBivector{3}) === Electrum.ByRealSpace()
+    @test Electrum.DataSpace(s_z) === Electrum.ByRealSpace()
 end


### PR DESCRIPTION
Notably, the `DataSpace` trait function has been internally deprecated and replaced with `BySpace`. There are also some new functions for checking that traits of different objects are compatible.